### PR TITLE
feat: 출근 등록 기능 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/backend.iml" filepath="$PROJECT_DIR$/.idea/backend.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/momentum-dao-be/build.gradle
+++ b/momentum-dao-be/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
     // swagger 관련 의존성 추가
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    // ip 로그인
+    implementation 'commons-net:commons-net:3.11.1'
 }
 
 tasks.named('test') {

--- a/momentum-dao-be/build.gradle
+++ b/momentum-dao-be/build.gradle
@@ -51,7 +51,8 @@ dependencies {
     implementation 'org.modelmapper:modelmapper:3.2.1'
 
     // ip 로그인
-    implementation 'commons-net:commons-net:3.11.1'
+    // https://mvnrepository.com/artifact/com.github.seancfoley/ipaddress
+    implementation 'com.github.seancfoley:ipaddress:5.5.0'
 }
 
 tasks.named('test') {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum ErrorCode {
+    // 출퇴근 오류
+    WORKTYPE_NOT_FOUND("10001", "존재하지 않는 근무 유형입니다.", HttpStatus.NOT_FOUND),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum ErrorCode {
     // 출퇴근 오류
-    WORKTYPE_NOT_FOUND("10001", "존재하지 않는 근무 유형입니다.", HttpStatus.NOT_FOUND),
+    WORKTYPE_NOT_FOUND("10001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),
+    IP_NOT_ALLOWED("10002", "출퇴근 등록이 불가능한 IP입니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     WORK_ALREADY_RECORDED("20005", "이미 출근 등록된 날짜입니다.", HttpStatus.BAD_REQUEST),
     ACCEPTED_WORK_ALREADY_RECORDED("20006", "재택근무/휴가/출장이 승인된 날짜입니다.", HttpStatus.BAD_REQUEST),
     WORKING_52H_NOT_ALLOWED("20007", "주 52시간 이상의 근무는 불가능합니다.", HttpStatus.BAD_REQUEST),
+    WORK_NOT_FOUND("20008", "시스템 오류입니다." ,HttpStatus.NOT_FOUND),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -12,6 +12,10 @@ public enum ErrorCode {
     WORKTYPE_NOT_FOUND("10001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),
     IP_NOT_ALLOWED("10002", "출퇴근 등록이 불가능한 IP입니다.", HttpStatus.BAD_REQUEST),
     INVALID_WORK_TIME("10003", "유효하지 않은 출퇴근 요청입니다.", HttpStatus.BAD_REQUEST),
+    WORK_REQUESTED_ON_HOLIDAY("10004", "승인 없는 주말/휴일 출근은 불가능합니다.", HttpStatus.BAD_REQUEST),
+    WORK_ALREADY_RECORDED("10005", "이미 출근 등록된 날짜입니다.", HttpStatus.BAD_REQUEST),
+    ACCEPTED_WORK_ALREADY_RECORDED("10006", "재택근무/휴가/출장이 승인된 날짜입니다.", HttpStatus.BAD_REQUEST),
+    WORKING_52H_NOT_ALLOWED("10007", "주 52시간 이상의 근무는 불가능합니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // 출퇴근 오류
     WORKTYPE_NOT_FOUND("10001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),
     IP_NOT_ALLOWED("10002", "출퇴근 등록이 불가능한 IP입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_WORK_TIME("10003", "유효하지 않은 출퇴근 요청입니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.dao.momentum.common.exception;
 
 
 import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.work.exception.WorkException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -23,6 +24,16 @@ public class GlobalExceptionHandler {
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorMessage.toString());
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(WorkException.class)
+    public ResponseEntity<ApiResponse<Void>> handleWorkException(WorkException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }
 
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
@@ -1,9 +1,7 @@
 package com.dao.momentum.work.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
-import com.dao.momentum.work.command.application.dto.request.WorkEndRequest;
 import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
-import com.dao.momentum.work.command.application.dto.response.WorkEndResponse;
 import com.dao.momentum.work.command.application.dto.response.WorkStartResponse;
 import com.dao.momentum.work.command.application.service.WorkCommandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
@@ -2,15 +2,13 @@ package com.dao.momentum.work.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
-import com.dao.momentum.work.command.application.dto.response.WorkCreateResponse;
+import com.dao.momentum.work.command.application.dto.response.WorkStartResponse;
 import com.dao.momentum.work.command.application.service.WorkCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +23,7 @@ public class WorkCommandController {
 
     @PostMapping
     @Operation(summary = "출근 등록", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다.")
-    public ResponseEntity<ApiResponse<WorkCreateResponse>> createWork(
+    public ResponseEntity<ApiResponse<WorkStartResponse>> createWork(
             @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
     ) {
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
@@ -1,7 +1,9 @@
 package com.dao.momentum.work.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.work.command.application.dto.request.WorkEndRequest;
 import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
+import com.dao.momentum.work.command.application.dto.response.WorkEndResponse;
 import com.dao.momentum.work.command.application.dto.response.WorkStartResponse;
 import com.dao.momentum.work.command.application.service.WorkCommandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,10 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/works")
@@ -26,12 +27,43 @@ public class WorkCommandController {
     @PostMapping
     @Operation(summary = "출근 등록", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다.")
     public ResponseEntity<ApiResponse<WorkStartResponse>> createWork(
-            @AuthenticationPrincipal UserDetails userDetails, @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
+            @AuthenticationPrincipal UserDetails userDetails, HttpServletRequest httpServletRequest
     ) {
+        LocalDateTime startPushedAt = LocalDateTime.now();
 
         return ResponseEntity.ok(
                 ApiResponse.success(
-                    workCommandService.createWork(userDetails, workStartRequest, httpServletRequest)
+                    workCommandService.createWork(userDetails, httpServletRequest, startPushedAt)
+                )
+        );
+    }
+
+//    @PutMapping
+//    @Operation(summary = "퇴근 등록", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다.")
+//    public ResponseEntity<ApiResponse<WorkEndResponse>> updateWork(
+//            @AuthenticationPrincipal UserDetails userDetails, @RequestBody WorkEndRequest workEndRequest, HttpServletRequest httpServletRequest
+//    ) {
+//
+//        return ResponseEntity.ok(
+//                ApiResponse.success(
+//                        workCommandService.updateWork(userDetails, workEndRequest, httpServletRequest)
+//                )
+//        );
+//    }
+
+    @PostMapping("/test")
+    @Operation(summary = "출근 등록 테스트", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다. (당일이 아니어도 출근 등록 가능)")
+    public ResponseEntity<ApiResponse<WorkStartResponse>> testCreateWork(
+            @AuthenticationPrincipal UserDetails userDetails, @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
+    ) {
+        LocalDateTime startPushedAt = LocalDateTime.now();
+        if (workStartRequest != null && workStartRequest.getStartPushedAt() != null) {
+            startPushedAt = workStartRequest.getStartPushedAt();
+        }
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        workCommandService.createWork(userDetails, httpServletRequest, startPushedAt)
                 )
         );
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,12 +26,12 @@ public class WorkCommandController {
     @PostMapping
     @Operation(summary = "출근 등록", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다.")
     public ResponseEntity<ApiResponse<WorkStartResponse>> createWork(
-            @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
+            @AuthenticationPrincipal UserDetails userDetails, @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
     ) {
 
         return ResponseEntity.ok(
                 ApiResponse.success(
-                    workCommandService.createWork(workStartRequest, httpServletRequest)
+                    workCommandService.createWork(userDetails, workStartRequest, httpServletRequest)
                 )
         );
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/controller/WorkCommandController.java
@@ -1,10 +1,40 @@
 package com.dao.momentum.work.command.application.controller;
 
+import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
+import com.dao.momentum.work.command.application.dto.response.WorkCreateResponse;
+import com.dao.momentum.work.command.application.service.WorkCommandService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/works")
+@RequiredArgsConstructor
 @Tag(name = "근태 관리", description = "출퇴근 기록 등록, 수정, 삭제 API")
 public class WorkCommandController {
+    private final WorkCommandService workCommandService;
+
+    @PostMapping
+    @Operation(summary = "출근 등록", description = "사원이 출근 버튼을 클릭하여 출근을 등록합니다.")
+    public ResponseEntity<ApiResponse<WorkCreateResponse>> createWork(
+            @RequestBody WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest
+    ) {
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                    workCommandService.createWork(workStartRequest, httpServletRequest)
+                )
+        );
+    }
+
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/request/WorkStartRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/request/WorkStartRequest.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.work.command.application.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class WorkStartRequest {
+    private LocalDateTime startPushedAt;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkCreateResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkCreateResponse.java
@@ -1,0 +1,10 @@
+package com.dao.momentum.work.command.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class WorkCreateResponse {
+    private WorkSummaryDTO workSummaryDTO;
+
+    private String message;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkStartResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkStartResponse.java
@@ -3,7 +3,7 @@ package com.dao.momentum.work.command.application.dto.response;
 import lombok.Builder;
 
 @Builder
-public class WorkCreateResponse {
+public class WorkStartResponse {
     private WorkSummaryDTO workSummaryDTO;
 
     private String message;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkStartResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkStartResponse.java
@@ -1,7 +1,8 @@
 package com.dao.momentum.work.command.application.dto.response;
 
-import lombok.Builder;
+import lombok.*;
 
+@Getter
 @Builder
 public class WorkStartResponse {
     private WorkSummaryDTO workSummaryDTO;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkSummaryDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkSummaryDTO.java
@@ -1,0 +1,30 @@
+package com.dao.momentum.work.command.application.dto.response;
+
+import com.dao.momentum.work.command.domain.aggregate.Work;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public class WorkSummaryDTO {
+    private long workId;
+
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+
+    private int breakTime;
+
+    private int workTime;
+
+    public static WorkSummaryDTO from(Work work) {
+
+        return WorkSummaryDTO.builder()
+                .workId(work.getWorkId())
+                .startAt(work.getStartAt())
+                .endAt(work.getEndAt())
+                .breakTime(work.getBreakTime())
+                .workTime((int) work.getWorkTime().toMinutes())
+                .build();
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkSummaryDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/dto/response/WorkSummaryDTO.java
@@ -2,9 +2,11 @@ package com.dao.momentum.work.command.application.dto.response;
 
 import com.dao.momentum.work.command.domain.aggregate.Work;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 public class WorkSummaryDTO {
     private long workId;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
@@ -1,9 +1,6 @@
 package com.dao.momentum.work.command.application.service;
 
 import com.dao.momentum.common.exception.ErrorCode;
-import com.dao.momentum.work.command.application.dto.request.WorkEndRequest;
-import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
-import com.dao.momentum.work.command.application.dto.response.WorkEndResponse;
 import com.dao.momentum.work.command.application.dto.response.WorkStartResponse;
 import com.dao.momentum.work.command.application.dto.response.WorkSummaryDTO;
 import com.dao.momentum.work.command.application.validator.IpValidator;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
@@ -7,30 +7,49 @@ import com.dao.momentum.work.command.application.dto.response.WorkSummaryDTO;
 import com.dao.momentum.work.command.domain.aggregate.IsNormalWork;
 import com.dao.momentum.work.command.domain.aggregate.Work;
 import com.dao.momentum.work.command.domain.aggregate.WorkType;
+import com.dao.momentum.work.command.domain.aggregate.WorkTypeName;
 import com.dao.momentum.work.command.domain.repository.WorkRepository;
 import com.dao.momentum.work.command.domain.repository.WorkTypeRepository;
 import com.dao.momentum.work.exception.WorkException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.net.util.SubnetUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WorkCommandService {
-    private static final int DEFAULT_WORK_HOURS = 9;
+    private static final int DEFAULT_WORK_HOURS = 8;
+    private static final int BREAK_30M_THRESHOLD = 4 * 60;
+    private static final int BREAK_60M_THRESHOLD = 8 * 60 + 30;
 
     private final WorkTypeRepository workTypeRepository;
     private final WorkRepository workRepository;
 
     public WorkCreateResponse createWork(WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest) {
+        String ip = httpServletRequest.getRemoteAddr();
+        log.info("출근 등록 요청 - IP: {}, 요청 시각: {}", ip, workStartRequest.getStartPushedAt());
+
+        List<String> AllowedIps = getAllowedIps();
+        if (!isvalidIp(ip, AllowedIps)) {
+            log.warn("허용되지 않은 IP 접근 시도: {}", ip);
+            throw new WorkException(ErrorCode.IP_NOT_ALLOWED);
+        }
+
         long empId = 1; // 로그인 구현 후 수정
-        WorkType workType = workTypeRepository.findByTypeName("WORK")
-                .orElseThrow(() -> new WorkException(ErrorCode.WORKTYPE_NOT_FOUND));
+        WorkType workType = workTypeRepository.findByTypeName(WorkTypeName.WORK.name())
+                .orElseThrow(() -> {
+                    log.error("WorkType '{}'을(를) 찾을 수 없음", WorkTypeName.WORK.name());
+                    return new WorkException(ErrorCode.WORKTYPE_NOT_FOUND);
+                });
 
         int typeId = workType.getTypeId();
 
@@ -49,17 +68,45 @@ public class WorkCommandService {
                 .breakTime(breakTime)
                 .build();
 
-        IsNormalWork isNormalWork = work.getWorkTime().toHours() >= 8? IsNormalWork.Y : IsNormalWork.N;
+        IsNormalWork isNormalWork = work.getWorkTime().toHours() >= DEFAULT_WORK_HOURS? IsNormalWork.Y : IsNormalWork.N;
         work.setIsNormalWork(isNormalWork);
 
         WorkSummaryDTO workSummaryDTO = WorkSummaryDTO.from(work);
 
         workRepository.save(work);
+        log.info("출근 등록 완료 - workId: {}, empId: {}, 등록일시: {}", work.getWorkId(), empId, startPushedAt);
+
 
         return WorkCreateResponse.builder()
                 .workSummaryDTO(workSummaryDTO)
                 .message("출근 등록 성공")
                 .build();
+    }
+
+    private List<String> getAllowedIps() {
+//        return List.of();
+        return List.of("0.0.0.0/0");
+    }
+
+    private boolean isvalidIp(String ip, List<String> allowedIps) {
+        for (String allowedIp : allowedIps) {
+            try {
+                if (allowedIp.contains("/")) {
+                    SubnetUtils subnet = new SubnetUtils(allowedIp);
+                    subnet.setInclusiveHostCount(true);
+                    if (subnet.getInfo().isInRange(ip)) {
+                        return true;
+                    }
+                } else {
+                    if (ip.equals(allowedIp)) {
+                        return true;
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                log.warn("잘못된 IP: {}", allowedIp, e);
+            }
+        }
+        return false;
     }
 
     private LocalDateTime computeStartAt(LocalDateTime startPushedAt) {
@@ -71,7 +118,8 @@ public class WorkCommandService {
     }
 
     private LocalTime getEndTime() {
-        return getStartTime().plusHours(DEFAULT_WORK_HOURS);
+        return getStartTime().plusHours(DEFAULT_WORK_HOURS).plusHours(1);
+        // 휴게시간 1시간 추가
     }
 
     private LocalTime getMidTime() {
@@ -80,10 +128,10 @@ public class WorkCommandService {
 
     private int getBreakTime(LocalDateTime startAt, LocalDateTime endAt) {
         long diff = Duration.between(startAt, endAt).toMinutes();
-        if (diff >= 8.5 * 60) { // 8시간 30분부터 30분 추가 부여 필요
+        if (diff >= BREAK_60M_THRESHOLD) { // 8시간 30분부터 30분 추가 부여 필요
             return 60;
         }
-        if (diff >= 4 * 60) { // 4시간 이상 체류 시 30분의 휴게 부여
+        if (diff >= BREAK_30M_THRESHOLD) { // 4시간 이상 체류 시 30분의 휴게 부여
             return 30;
         }
         return 0;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
@@ -16,6 +16,7 @@ import com.dao.momentum.work.exception.WorkException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -34,14 +35,14 @@ public class WorkCommandService {
     private final WorkCreateValidator workCreateValidator;
     private final WorkTimeService workTimeService;
 
-    public WorkStartResponse createWork(WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest) {
+    public WorkStartResponse createWork(UserDetails userDetails, WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest) {
         String ip = extractClientIp(httpServletRequest);
         LocalDateTime startPushedAt = workStartRequest.getStartPushedAt();
         log.info("출근 등록 요청 - IP: {}, 요청 시각: {}", ip, startPushedAt);
 
         ipValidator.validateIp(ip, getAllowedIps());
 
-        long empId = 1; // 로그인 구현 후 수정
+        long empId = Long.parseLong(userDetails.getUsername()); // 로그인 구현 후 수정
         LocalDate today = LocalDate.now();
 
         boolean hasAMHalfDayoff = workCreateValidator.hasAMHalfDayOff(empId, today);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
@@ -77,7 +77,7 @@ public class WorkCommandService {
                 .breakTime(breakTime)
                 .build();
 
-        int requiredMinutes = WorkTimeService.DEFAULT_WORK_HOURS;
+        int requiredMinutes = WorkTimeService.DEFAULT_WORK_HOURS * 60;
         if (hasAMHalfDayoff || hasPMHalfDayoff) {
             requiredMinutes /= 2;
         }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkCommandService.java
@@ -1,8 +1,101 @@
 package com.dao.momentum.work.command.application.service;
 
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
+import com.dao.momentum.work.command.application.dto.response.WorkCreateResponse;
+import com.dao.momentum.work.command.application.dto.response.WorkSummaryDTO;
+import com.dao.momentum.work.command.domain.aggregate.IsNormalWork;
+import com.dao.momentum.work.command.domain.aggregate.Work;
+import com.dao.momentum.work.command.domain.aggregate.WorkType;
+import com.dao.momentum.work.command.domain.repository.WorkRepository;
+import com.dao.momentum.work.command.domain.repository.WorkTypeRepository;
+import com.dao.momentum.work.exception.WorkException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 @Service
+@RequiredArgsConstructor
 public class WorkCommandService {
+    private static final int DEFAULT_WORK_HOURS = 9;
+
+    private final WorkTypeRepository workTypeRepository;
+    private final WorkRepository workRepository;
+
+    public WorkCreateResponse createWork(WorkStartRequest workStartRequest, HttpServletRequest httpServletRequest) {
+        long empId = 1; // 로그인 구현 후 수정
+        WorkType workType = workTypeRepository.findByTypeName("WORK")
+                .orElseThrow(() -> new WorkException(ErrorCode.WORKTYPE_NOT_FOUND));
+
+        int typeId = workType.getTypeId();
+
+        LocalDateTime startPushedAt = workStartRequest.getStartPushedAt();
+        LocalDateTime startAt = computeStartAt(startPushedAt);
+        LocalDateTime endAt = LocalDateTime.of(LocalDate.now(), getEndTime());
+
+        int breakTime = getBreakTime(startAt, endAt);
+
+        Work work = Work.builder()
+                .empId(empId)
+                .typeId(typeId)
+                .startAt(startAt)
+                .endAt(endAt)
+                .startPushedAt(startPushedAt)
+                .breakTime(breakTime)
+                .build();
+
+        IsNormalWork isNormalWork = work.getWorkTime().toHours() >= 8? IsNormalWork.Y : IsNormalWork.N;
+        work.setIsNormalWork(isNormalWork);
+
+        WorkSummaryDTO workSummaryDTO = WorkSummaryDTO.from(work);
+
+        workRepository.save(work);
+
+        return WorkCreateResponse.builder()
+                .workSummaryDTO(workSummaryDTO)
+                .message("출근 등록 성공")
+                .build();
+    }
+
+    private LocalDateTime computeStartAt(LocalDateTime startPushedAt) {
+        return getLaterOne(startPushedAt, LocalDate.now().atTime(getStartTime()));
+    }
+
+    private LocalTime getStartTime() {
+        return LocalTime.of(9, 0); // 회사 정보로 수정 필요
+    }
+
+    private LocalTime getEndTime() {
+        return getStartTime().plusHours(DEFAULT_WORK_HOURS);
+    }
+
+    private LocalTime getMidTime() {
+        return getStartTime().plusMinutes((long) 4.5 * 60);
+    }
+
+    private int getBreakTime(LocalDateTime startAt, LocalDateTime endAt) {
+        long diff = Duration.between(startAt, endAt).toMinutes();
+        if (diff >= 8.5 * 60) { // 8시간 30분부터 30분 추가 부여 필요
+            return 60;
+        }
+        if (diff >= 4 * 60) { // 4시간 이상 체류 시 30분의 휴게 부여
+            return 30;
+        }
+        return 0;
+    }
+
+    private LocalDateTime getEarlierOne(LocalDateTime first, LocalDateTime second) {
+        return first.isBefore(second)? first : second;
+    }
+
+    private LocalDateTime getLaterOne(LocalDateTime first, LocalDateTime second) {
+        return first.isAfter(second)? first : second;
+    }
+
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
@@ -1,0 +1,60 @@
+package com.dao.momentum.work.command.application.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+public class WorkTimeService {
+    public static final int DEFAULT_WORK_HOURS = 8;
+    private static final int BREAK_30M_THRESHOLD = 4 * 60;
+    private static final int BREAK_60M_THRESHOLD = 8 * 60 + 30;
+
+    public LocalTime getStartTime() {
+        return LocalTime.of(9, 0); // 회사 정보로 수정 필요
+    }
+
+    public LocalTime getMidTime() {
+        return getStartTime().plusHours(4).plusMinutes(30);
+    }
+
+    public LocalTime getEndTime() {
+        return getStartTime().plusHours(DEFAULT_WORK_HOURS).plusHours(1);
+        // 휴게시간 1시간 추가
+    }
+
+    public int getBreakTime(LocalDateTime startAt, LocalDateTime endAt) {
+        long diff = Duration.between(startAt, endAt).toMinutes();
+        if (diff >= BREAK_60M_THRESHOLD) { // 8시간 30분부터 30분 추가 부여 필요
+            return 60;
+        }
+        if (diff >= BREAK_30M_THRESHOLD) { // 4시간 이상 체류 시 30분의 휴게 부여
+            return 30;
+        }
+        return 0;
+    }
+
+    public LocalDateTime getEarlierOne(LocalDateTime first, LocalDateTime second) {
+        return first.isBefore(second) ? first : second;
+    }
+
+    public LocalDateTime getLaterOne(LocalDateTime first, LocalDateTime second) {
+        return first.isAfter(second) ? first : second;
+    }
+
+    LocalDateTime computeStartAt(LocalDateTime startPushedAt, boolean hasAMHalfDayOff) {
+        LocalDate startPushedDate = startPushedAt.toLocalDate();
+        LocalTime startTime = getStartTime();
+        LocalDateTime startAtByPolicy = startPushedDate.atTime(startTime);
+        LocalTime midTime = getMidTime();
+        LocalDateTime startAtByPolicyForAMDayoff = startPushedDate.atTime(midTime);
+
+        if (hasAMHalfDayOff) {
+            return getLaterOne(startPushedAt, startAtByPolicyForAMDayoff);
+        }
+        return getLaterOne(startPushedAt, startAtByPolicy);
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
@@ -57,4 +57,17 @@ public class WorkTimeService {
         }
         return getLaterOne(startPushedAt, startAtByPolicy);
     }
+
+    LocalDateTime computeEndAt(LocalDateTime endPushedAt, boolean hasPMHalfDayOff) {
+        LocalDate endPushedDate = endPushedAt.toLocalDate();
+        LocalTime endTime = getEndTime();
+        LocalDateTime endAtByPolicy = endPushedDate.atTime(endTime);
+        LocalTime midTime = getMidTime();
+        LocalDateTime endAtByPolicyForPMDayoff = endPushedDate.atTime(midTime);
+
+        if (hasPMHalfDayOff) {
+            return getEarlierOne(endPushedAt, endAtByPolicyForPMDayoff);
+        }
+        return getEarlierOne(endPushedAt, endAtByPolicy);
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/IpValidator.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/IpValidator.java
@@ -1,0 +1,35 @@
+package com.dao.momentum.work.command.application.validator;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.exception.WorkException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.net.util.SubnetUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IpValidator {
+
+    public void validateIp(String ip, List<String> allowedIps) {
+        boolean allowed = allowedIps.stream().anyMatch(allowedIp -> {
+            try {
+                if (allowedIp.contains("/")) {
+                    SubnetUtils subnet = new SubnetUtils(allowedIp);
+                    subnet.setInclusiveHostCount(true);
+                    return subnet.getInfo().isInRange(ip);
+                }
+                return allowedIp.equals(ip);
+            } catch (IllegalArgumentException e) {
+                log.warn("잘못된 IP 형식: {}", allowedIp);
+                return false;
+            }
+        });
+
+        if (!allowed) throw new WorkException(ErrorCode.IP_NOT_ALLOWED);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/WorkCreateValidator.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/WorkCreateValidator.java
@@ -76,15 +76,12 @@ public class WorkCreateValidator {
             }
 
             if (typeName == WorkTypeName.VACATION) {
-                if (hasAMHalfDayOff(empId, date) || hasPMHalfDayOff(empId, date)) {
-                    return true;
-                }
 
                 // 반차가 아닌 일반 휴가 중 겹치는 일정이 있는지 체크
                 LocalDateTime vacationStart = foundWork.getStartAt();
                 LocalDateTime vacationEnd = foundWork.getEndAt();
 
-                boolean overlaps = vacationStart.isBefore(endAt) && vacationEnd.isAfter(startAt);
+                boolean overlaps = vacationStart.equals(startAt) && vacationEnd.equals(endAt);
 
                 if (overlaps) return true;
 
@@ -132,8 +129,8 @@ public class WorkCreateValidator {
             throw new WorkException(ErrorCode.INVALID_WORK_TIME);
         }
 
-        if (startAt.isAfter(endAt)) {
-            log.warn("잘못된 출근 요청 - 출근 시각이 종료 시각보다 늦음: startAt={}, endAt={}", startAt, endAt);
+        if (!startAt.isBefore(endAt)) {
+            log.warn("잘못된 출근 요청 - 출근 시각이 종료 시각보다 늦거나 같음: startAt={}, endAt={}", startAt, endAt);
             throw new WorkException(ErrorCode.INVALID_WORK_TIME);
         }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/WorkCreateValidator.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/validator/WorkCreateValidator.java
@@ -1,0 +1,143 @@
+package com.dao.momentum.work.command.application.validator;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.command.application.service.WorkTimeService;
+import com.dao.momentum.work.command.domain.aggregate.Work;
+import com.dao.momentum.work.command.domain.aggregate.WorkType;
+import com.dao.momentum.work.command.domain.aggregate.WorkTypeName;
+import com.dao.momentum.work.command.domain.repository.WorkRepository;
+import com.dao.momentum.work.command.domain.repository.WorkTypeRepository;
+import com.dao.momentum.work.exception.WorkException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WorkCreateValidator {
+
+    private final WorkRepository workRepository;
+    private final WorkTypeRepository workTypeRepository;
+    private final WorkTimeService workTimeService;
+
+    public void validateWorkCreation(long empId, LocalDate today, LocalDateTime startPushedAt, LocalDateTime startAt, LocalDateTime endAt) {
+        if (workAlreadyRecorded(empId, today)) {
+            throw new WorkException(ErrorCode.WORK_ALREADY_RECORDED);
+        }
+
+        if (hasApprovedWork(empId, today)) {
+            throw new WorkException(ErrorCode.ACCEPTED_WORK_ALREADY_RECORDED);
+        }
+
+        if (isHoliday(today)) {
+            throw new WorkException(ErrorCode.WORK_REQUESTED_ON_HOLIDAY);
+        }
+
+        validateStartAt(startAt, endAt, startPushedAt, today);
+    }
+
+    // 이미 등록된 출근 기록이 있는 지 체크
+    public boolean workAlreadyRecorded(long empId, LocalDate date) {
+        return workRepository.existsByEmpIdAndStartAtDateAndTypeName(empId, date, WorkTypeName.WORK);
+    }
+
+    // 승인된 휴가/출장/재택 근무가 있는 지 체크
+    public boolean hasApprovedWork(long empId, LocalDate date) {
+        List<WorkTypeName> typeNames = List.of(
+                WorkTypeName.REMOTE_WORK,
+                WorkTypeName.VACATION,
+                WorkTypeName.BUSINESS_TRIP
+        );
+
+        List<Work> works = workRepository.findAllByEmpIdAndDateAndTypeNames(empId, date, typeNames);
+
+        LocalTime startTime = workTimeService.getStartTime();
+        LocalTime endTime = workTimeService.getEndTime();
+
+        LocalDateTime startAt = LocalDateTime.of(date, startTime);
+        LocalDateTime endAt = LocalDateTime.of(date, endTime);
+
+        for (Work foundWork : works) {
+            int typeId = foundWork.getTypeId();
+            WorkType type = workTypeRepository.findById(typeId)
+                    .orElseThrow(() -> new WorkException(ErrorCode.WORKTYPE_NOT_FOUND));
+
+            WorkTypeName typeName = type.getTypeName();
+
+            if (typeName == WorkTypeName.REMOTE_WORK || typeName == WorkTypeName.BUSINESS_TRIP) {
+                return true;
+            }
+
+            if (typeName == WorkTypeName.VACATION) {
+                if (hasAMHalfDayOff(empId, date) || hasPMHalfDayOff(empId, date)) {
+                    return true;
+                }
+
+                // 반차가 아닌 일반 휴가 중 겹치는 일정이 있는지 체크
+                LocalDateTime vacationStart = foundWork.getStartAt();
+                LocalDateTime vacationEnd = foundWork.getEndAt();
+
+                boolean overlaps = vacationStart.isBefore(endAt) && vacationEnd.isAfter(startAt);
+
+                if (overlaps) return true;
+
+            }
+        }
+
+        return false;
+    }
+
+    private boolean hasHalfDayOff(long empId, LocalDate date, LocalTime start, LocalTime end) {
+        return workRepository.findAllByEmpIdAndDateAndTypeNames(empId, date, List.of(WorkTypeName.VACATION))
+                .stream()
+                .anyMatch(work -> work.getStartAt().toLocalTime().equals(start) &&
+                        work.getEndAt().toLocalTime().equals(end));
+    }
+
+    public boolean hasAMHalfDayOff(long empId, LocalDate date) {
+        LocalTime startTime = workTimeService.getStartTime();
+        LocalTime midTime = workTimeService.getMidTime();
+        return hasHalfDayOff(empId, date, startTime, midTime);
+    }
+
+    public boolean hasPMHalfDayOff(long empId, LocalDate date) {
+        LocalTime midTime = workTimeService.getMidTime();
+        LocalTime endTime = workTimeService.getEndTime();
+        return hasHalfDayOff(empId, date, midTime, endTime);
+    }
+
+    // 휴일인지 체크
+    public boolean isHoliday(LocalDate date) {
+        if (date.getDayOfWeek() == DayOfWeek.SUNDAY || date.getDayOfWeek() == DayOfWeek.SATURDAY) {
+            return true;
+        }
+
+        // 회사 휴일 테이블에 등록된 날짜이면 return true 추가 필요
+
+        return false;
+    }
+
+    public void validateStartAt(LocalDateTime startAt, LocalDateTime endAt, LocalDateTime startPushedAt, LocalDate today) {
+        LocalDate pushedDate = startPushedAt.toLocalDate();
+
+        if (!pushedDate.isEqual(today)) {
+            log.warn("잘못된 출근 요청 - 출근 시각이 오늘 날짜가 아님: {}", startAt.toLocalDate());
+            throw new WorkException(ErrorCode.INVALID_WORK_TIME);
+        }
+
+        if (startAt.isAfter(endAt)) {
+            log.warn("잘못된 출근 요청 - 출근 시각이 종료 시각보다 늦음: startAt={}, endAt={}", startAt, endAt);
+            throw new WorkException(ErrorCode.INVALID_WORK_TIME);
+        }
+
+    }
+
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
@@ -47,6 +47,12 @@ public class Work {
         this.startPushedAt = startPushedAt;
     }
 
+    public void fromUpdate(LocalDateTime endAt, LocalDateTime endPushedAt, int breakTime) {
+        this.endAt = endAt;
+        this.endPushedAt = endPushedAt;
+        this.breakTime = breakTime;
+    }
+
     public Duration getWorkTime() {
         return Duration.between(this.startAt, this.endAt)
                 .minusMinutes(this.breakTime);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
@@ -2,9 +2,12 @@ package com.dao.momentum.work.command.domain.aggregate;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Entity
@@ -30,7 +33,23 @@ public class Work {
 
     private LocalDateTime endPushedAt;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private IsNormalWork isNormalWork;
+
+    @Builder
+    public Work(long empId, int typeId, LocalDateTime startAt, LocalDateTime endAt, int breakTime, LocalDateTime startPushedAt) {
+        this.empId = empId;
+        this.typeId = typeId;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.breakTime = breakTime;
+        this.startPushedAt = startPushedAt;
+    }
+
+    public Duration getWorkTime() {
+        return Duration.between(this.startAt, this.endAt)
+                .minusMinutes(this.breakTime);
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
@@ -52,4 +52,8 @@ public class Work {
                 .minusMinutes(this.breakTime);
     }
 
+    public boolean isNormalWork(long requiredMinutes) {
+        return this.getWorkTime().toMinutes() >= requiredMinutes;
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkType.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkType.java
@@ -1,18 +1,15 @@
 package com.dao.momentum.work.command.domain.aggregate;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.persistence.*;
 import lombok.Getter;
 
+@Getter
 @Entity
 @Table(name = "work_type")
 public class WorkType {
     @Id
-    @Getter
     private int typeId;
 
-    @NotBlank
-    private String typeName;
+    @Enumerated(EnumType.STRING)
+    private WorkTypeName typeName;
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkType.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkType.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
 
 @Entity
 @Table(name = "work_type")
 public class WorkType {
     @Id
+    @Getter
     private int typeId;
 
     @NotBlank

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkTypeName.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkTypeName.java
@@ -1,0 +1,25 @@
+package com.dao.momentum.work.command.domain.aggregate;
+
+import lombok.Getter;
+
+@Getter
+public enum WorkTypeName {
+    WORK("근무"),
+    REMOTE_WORK("재택근무"),
+    VACATION("휴가"),
+    OVERTIME("연장근무"),
+    NIGHT("야간근무"),
+    HOLIDAY("휴일근무"),
+    BUSINESS_TRIP("출장");
+
+    private final String description;
+
+    WorkTypeName(String description) {
+        this.description = description;
+    }
+
+    public String getTypeName() {
+        return name();
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
@@ -1,4 +1,7 @@
 package com.dao.momentum.work.command.domain.repository;
 
+import com.dao.momentum.work.command.domain.aggregate.Work;
+
 public interface WorkRepository {
+    Work save(Work work);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Work;
+import com.dao.momentum.work.command.domain.aggregate.WorkTypeName;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.Query;
 
@@ -19,7 +20,7 @@ public interface WorkRepository {
             AND wt.typeName = :typeName
             """)
     boolean existsByEmpIdAndStartAtDateAndTypeName(
-            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") String typeName
+            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") WorkTypeName typeName
     );
 
     @Query("""
@@ -31,7 +32,7 @@ public interface WorkRepository {
             AND wt.typeName IN :typeNames
             """)
     boolean existsByEmpIdAndStartAtDateAndTypeNames(
-            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") List<String> typeNames
+            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") List<WorkTypeName> typeNames
     );
 
     @Query("""
@@ -45,7 +46,7 @@ public interface WorkRepository {
     List<Work> findAllByEmpIdAndDateAndTypeNames(
             @Param("empId") long empId,
             @Param("date") LocalDate date,
-            @Param("typeNames") List<String> typeNames
+            @Param("typeNames") List<WorkTypeName> typeNames
     );
 
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
@@ -1,12 +1,14 @@
 package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Work;
+import com.dao.momentum.work.command.domain.aggregate.WorkType;
 import com.dao.momentum.work.command.domain.aggregate.WorkTypeName;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface WorkRepository {
     Work save(Work work);
@@ -49,5 +51,14 @@ public interface WorkRepository {
             @Param("typeNames") List<WorkTypeName> typeNames
     );
 
-
+    @Query("""
+            SELECT w
+            FROM Work w
+            JOIN WorkType wt ON w.typeId = wt.typeId
+            WHERE w.empId = :empId
+              AND FUNCTION('DATE', w.startAt) = :date
+              AND wt.typeName = :workType
+            """)
+    Optional<Work> findByEmpIdAndDateAndTypeName(
+            long empId, LocalDate today, WorkType workType);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkRepository.java
@@ -1,7 +1,52 @@
 package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Work;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface WorkRepository {
     Work save(Work work);
+
+    @Query("""
+            SELECT CASE WHEN COUNT(w) > 0 THEN true ELSE false END
+            FROM Work w
+            JOIN WorkType wt on w.typeId = wt.typeId
+            WHERE w.empId = :empId
+            AND FUNCTION('DATE', w.startAt) = :date
+            AND wt.typeName = :typeName
+            """)
+    boolean existsByEmpIdAndStartAtDateAndTypeName(
+            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") String typeName
+    );
+
+    @Query("""
+            SELECT CASE WHEN COUNT(w) > 0 THEN true ELSE false END
+            FROM Work w
+            JOIN WorkType wt on w.typeId = wt.typeId
+            WHERE w.empId = :empId
+            AND FUNCTION('DATE', w.startAt) = :date
+            AND wt.typeName IN :typeNames
+            """)
+    boolean existsByEmpIdAndStartAtDateAndTypeNames(
+            @Param("empId") long empId, @Param("date") LocalDate date, @Param("typeName") List<String> typeNames
+    );
+
+    @Query("""
+            SELECT w
+            FROM Work w
+            JOIN WorkType wt ON w.typeId = wt.typeId
+            WHERE w.empId = :empId
+              AND FUNCTION('DATE', w.startAt) = :date
+              AND wt.typeName IN :typeNames
+            """)
+    List<Work> findAllByEmpIdAndDateAndTypeNames(
+            @Param("empId") long empId,
+            @Param("date") LocalDate date,
+            @Param("typeNames") List<String> typeNames
+    );
+
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
@@ -1,10 +1,13 @@
 package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.WorkType;
+import com.dao.momentum.work.command.domain.aggregate.WorkTypeName;
 
 import java.util.Optional;
 
 public interface WorkTypeRepository {
 
     Optional<WorkType> findByTypeName(String work);
+
+    Optional<WorkType> findById(int typeId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface WorkTypeRepository {
 
-    Optional<WorkType> findByTypeName(String work);
+    Optional<WorkType> findByTypeName(WorkTypeName workType);
 
     Optional<WorkType> findById(int typeId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkTypeRepository.java
@@ -1,4 +1,10 @@
 package com.dao.momentum.work.command.domain.repository;
 
+import com.dao.momentum.work.command.domain.aggregate.WorkType;
+
+import java.util.Optional;
+
 public interface WorkTypeRepository {
+
+    Optional<WorkType> findByTypeName(String work);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/exception/WorkException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/exception/WorkException.java
@@ -1,7 +1,9 @@
 package com.dao.momentum.work.exception;
 
 import com.dao.momentum.common.exception.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class WorkException extends RuntimeException {
     ErrorCode errorCode;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/exception/WorkException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/exception/WorkException.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.work.exception;
+
+import com.dao.momentum.common.exception.ErrorCode;
+
+public class WorkException extends RuntimeException {
+    ErrorCode errorCode;
+
+    public WorkException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/momentum-dao-be/src/test/java/com/dao/momentum/work/command/application/controller/WorkCommandControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/work/command/application/controller/WorkCommandControllerTest.java
@@ -1,0 +1,135 @@
+package com.dao.momentum.work.command.application.controller;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.command.application.dto.request.WorkStartRequest;
+import com.dao.momentum.work.command.application.dto.response.WorkStartResponse;
+import com.dao.momentum.work.command.application.dto.response.WorkSummaryDTO;
+import com.dao.momentum.work.command.application.service.WorkCommandService;
+import com.dao.momentum.work.exception.WorkException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WorkCommandController.class)
+@AutoConfigureMockMvc
+class WorkCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private WorkCommandService workCommandService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void 출근_성공_850_출근등록() throws Exception {
+        WorkStartRequest request = WorkStartRequest.builder()
+                .startPushedAt(LocalDateTime.of(2025, 6, 13, 8, 50, 40))
+                .build(); // 생성자에 맞게 초기화
+        WorkStartResponse response = WorkStartResponse.builder()
+                .workSummaryDTO(
+                        WorkSummaryDTO.builder()
+                                .workId(1)
+                                .startAt(LocalDateTime.of(2025, 6, 13, 9, 0, 0))
+                                .endAt(LocalDateTime.of(2025, 6, 13, 18, 0, 0))
+                                .breakTime(60)
+                                .workTime(480)
+                                .build()
+                ).message("")
+                .build();
+
+        given(workCommandService.createWork(any(), any(), any())).willReturn(response);
+
+        mockMvc.perform(post("/works")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user("곽진웅").password("Test1234!").roles("ADMIN"))
+                        .with(csrf())
+                        .with(req -> {
+                            req.setRemoteAddr("127.0.0.1");
+                            return req;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.workSummaryDTO.startAt").value("2025-06-13T09:00:00"))
+                .andExpect(jsonPath("$.data.workSummaryDTO.endAt").value("2025-06-13T18:00:00"));
+    }
+
+    @Test
+    void 출근_성공_910_출근등록() throws Exception {
+        WorkStartRequest request = WorkStartRequest.builder()
+                .startPushedAt(LocalDateTime.of(2025, 6, 13, 9, 10, 40))
+                .build(); // 생성자에 맞게 초기화
+        WorkStartResponse response = WorkStartResponse.builder()
+                .workSummaryDTO(
+                        WorkSummaryDTO.builder()
+                                .workId(1)
+                                .startAt(LocalDateTime.of(2025, 6, 13, 9, 10, 0))
+                                .endAt(LocalDateTime.of(2025, 6, 13, 18, 0, 0))
+                                .breakTime(60)
+                                .workTime(470)
+                                .build()
+                ).message("")
+                .build();
+
+        given(workCommandService.createWork(any(), any(), any())).willReturn(response);
+
+        mockMvc.perform(post("/works")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user("곽진웅").password("Test1234!").roles("ADMIN"))
+                        .with(csrf())
+                        .with(req -> {
+                            req.setRemoteAddr("127.0.0.1");
+                            return req;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.workSummaryDTO.startAt").value("2025-06-13T09:10:00"))
+                .andExpect(jsonPath("$.data.workSummaryDTO.endAt").value("2025-06-13T18:00:00"));
+    }
+
+    @Test
+    void 출근_실패_허용IP없음() throws Exception {
+        WorkStartRequest request = WorkStartRequest.builder()
+                .startPushedAt(LocalDateTime.of(2025, 6, 13, 8, 50, 40))
+                .build();
+
+        // IP 미허용 상황을 가정해 예외 발생
+        given(workCommandService.createWork(any(), any(), any()))
+                .willThrow(new WorkException(ErrorCode.IP_NOT_ALLOWED));
+
+        mockMvc.perform(post("/works")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user("곽진웅").password("Test1234!").roles("ADMIN"))
+                        .with(csrf())
+                        .with(req -> {
+                            req.setRemoteAddr("192.168.0.123");
+                            return req;
+                        }))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("출퇴근 등록이 불가능한 IP입니다."));
+    }
+}


### PR DESCRIPTION
closes null
(퇴근 등록까지 구현해야 이슈 완료)
---

📌 개요
- 출근 등록 기능 구현

🔨 주요 변경 사항
- 출근 등록 기능 구현 (검증 로직 포함)
- 검증 로직이 길어서 유지보수를 위해 Validator 등 클래스로 분리
- String으로 관리하던 `WorkTypeName`을 Enum으로 수정
- GlobalExceptionHandler에 `WorkException`에 대한 핸들링 추가 
- 테스트 코드 작성

✅ 리뷰 요청 사항

⭐ 관련 이슈

#13
---
일단 기본적인 출근 등록은 잘 구현된 것으로 보이고, 복잡한 경우는 초기 데이터 생기고 Postman으로 제대로 해봐야할 듯합니다.
로직이 지금도 꽤 복잡해서, 일단 주 52시간 이상 근무 불가 로직은 따로 이슈 파고 추후에 가능하면 구현할까 생각 중입니다.
(성능적인 부분도 우려됨)