### PR TITLE
feat : 받은 문서 조회 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveController.java
@@ -1,0 +1,45 @@
+package com.dao.momentum.approve.query.controller;
+
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveResponse;
+import com.dao.momentum.approve.query.service.ApproveService;
+import com.dao.momentum.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/approval")
+@Tag(name = "결재 내역 조회 및 추가", description ="결재 내역 조회 및 추가 API")
+@RequiredArgsConstructor
+public class ApproveController {
+
+    private final ApproveService approveService;
+
+    // 받은 결재 문서 조회 기능
+    @GetMapping("/documents/received")
+    @Operation(summary = "받은 결재 문서 조회", description = "사원이 받은(승인해야 하는) 결재 문서를 조회합니다.")
+    public ResponseEntity<ApiResponse<ApproveResponse>> getReceivedApprovals(
+            @Validated ApproveListRequest approveListRequest,
+            @AuthenticationPrincipal UserDetails userDetails,
+            PageRequest pageRequest
+    ) {
+
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        ApproveResponse approveResponse
+                = approveService.getReceivedApprove(approveListRequest, empId ,pageRequest);
+
+        return ResponseEntity.ok(ApiResponse.success(approveResponse));
+    }
+
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveMapper.java
@@ -1,0 +1,29 @@
+package com.dao.momentum.approve.query.mapper;
+
+import com.dao.momentum.approve.query.dto.ApproveDTO;
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ApproveMapper {
+
+    List<ApproveDTO> findReceivedApproval(
+            @Param("req") ApproveListRequest approveListRequest,
+            @Param("empId") Long empId,
+            @Param("pageRequest") PageRequest pageRequest
+    );
+
+    long countReceivedApproval(
+            @Param("req") ApproveListRequest approveListRequest,
+            @Param("empId") Long empId
+    );
+
+    boolean existsByEmpId(Long empId);
+
+}
+
+                            

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveService.java
@@ -1,0 +1,15 @@
+package com.dao.momentum.approve.query.service;
+
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveResponse;
+
+public interface ApproveService {
+
+    ApproveResponse getReceivedApprove(
+            ApproveListRequest approveListRequest,
+            Long empId,
+            PageRequest pageRequest
+    );
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveServiceImpl.java
@@ -1,0 +1,66 @@
+package com.dao.momentum.approve.query.service;
+
+import com.dao.momentum.approve.exception.NotExistTabException;
+import com.dao.momentum.approve.query.dto.ApproveDTO;
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveResponse;
+import com.dao.momentum.approve.query.mapper.ApproveMapper;
+import com.dao.momentum.common.dto.Pagination;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.organization.employee.exception.EmployeeException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ApproveServiceImpl implements ApproveService {
+
+    private final ApproveMapper approveMapper;
+
+    /* 받은 결재 목록을 조회하는 메서드 */
+    @Transactional(readOnly = true)
+    public ApproveResponse getReceivedApprove(
+            ApproveListRequest approveListRequest, Long empId, PageRequest pageRequest
+    ) {
+
+        // 존재하지 않는 결재 탭을 입력하는 경우 에러 처리
+        List<String> validTabs = List.of("ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
+
+        if (!validTabs.contains(approveListRequest.getTab())) {
+            throw new NotExistTabException(ErrorCode.NOT_EXIST_TAB);
+        }
+
+        // 멤버 존재 여부에 따른 에러 처리
+        if(!approveMapper.existsByEmpId(empId)) {
+            throw new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND);
+        }
+
+        // 받은 결재 문서 가져오기
+        List<ApproveDTO> approveList
+                = approveMapper.findReceivedApproval(approveListRequest, empId ,pageRequest);
+
+        // 받은 결재 문서 개수 세기
+        long total = approveMapper.countReceivedApproval(approveListRequest, empId);
+
+        // 페이징 처리를 위한 부분
+        int page = pageRequest.getPage();
+        int size = pageRequest.getSize();
+
+        return ApproveResponse.builder()
+                .approveDTO(approveList)
+                .pagination(Pagination.builder()
+                        .currentPage(page)
+                        .totalPage((int)Math.ceil((double)total/size))
+                        .totalItems(total)
+                        .build())
+                .build();
+    }
+
+
+}

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveMapper.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.approve.query.mapper.ApproveMapper">
+
+    <select id="findReceivedApproval" resultType="com.dao.momentum.approve.query.dto.ApproveDTO">
+        SELECT
+            a.approve_id,
+            a.parent_approve_id,
+            s.status_type,
+            a.emp_id,
+            a.approve_title,
+            a.approve_type,
+            a.create_at,
+            a.complete_at,
+            e.name AS employee_name,
+            d.name AS department_name
+        FROM approve a
+        LEFT JOIN approve aa ON a.parent_approve_id = aa.approve_id
+        JOIN employee e ON a.emp_id = e.emp_id
+        JOIN department d ON e.dept_id = d.dept_id
+        JOIN status s ON a.status_id = s.status_id
+        JOIN approve_line al ON al.approve_id = a.approve_id
+        JOIN approve_line_list ali ON al.approve_line_id = ali.approve_line_id
+
+        WHERE ali.emp_id = #{empId}
+
+        <!-- 탭 조건 -->
+        <if test="req.tab == 'ATTENDANCE'">
+            AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
+            <!-- 근태 관련된 상세 필터 -->
+            <if test="req.approveType != null and req.approveType != ''">
+                AND a.approve_type = #{req.approveType}
+            </if>
+        </if>
+        <if test="req.tab == 'PROPOSAL'">
+            AND a.approve_type = 'PROPOSAL'
+        </if>
+        <if test="req.tab == 'RECEIPT'">
+            AND a.approve_type = 'RECEIPT'
+            <if test="req.receiptType != null and req.receiptType != ''">
+                AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+            </if>
+        </if>
+        <if test="req.tab == 'CANCEL'">
+            AND a.approve_type = 'CANCEL'
+        </if>
+
+        <!-- 상태  -->
+        <if test="req.status != null">
+            AND a.status_id = #{req.status}
+        </if>
+
+        <!-- 제목 -->
+        <if test="req.title != null and req.title != ''">
+            AND a.approve_title LIKE CONCAT('%', #{req.title}, '%')
+        </if>
+
+        <!-- 작성자 -->
+        <if test="req.employeeName != null and req.employeeName != ''">
+            AND e.name LIKE CONCAT('%', #{req.employeeName}, '%')
+        </if>
+
+        <!-- 작성일 -->
+        <if test="req.startDate != null and req.endDate != null">
+            AND a.create_at BETWEEN #{req.startDate} AND #{req.endDate}
+        </if>
+        <if test="req.startDate != null and req.endDate == null">
+            AND a.create_at &gt; #{req.startDate}
+        </if>
+        <if test="req.startDate == null and req.endDate != null">
+            AND a.create_at &lt; #{req.endDate}
+        </if>
+
+        <!-- 부서 -->
+        <if test="req.departmentName != null and req.departmentName != ''">
+            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        </if>
+
+        <!-- 완료 날짜를 기준으로 정렬 -->
+        ORDER BY
+        <choose>
+            <when test="req.sort == 'asc'">a.complete_at ASC</when>
+            <when test="req.sort == 'desc'">a.complete_at DESC</when>
+            <otherwise>a.complete_at DESC</otherwise>
+        </choose>
+
+        LIMIT #{pageRequest.limit} OFFSET #{pageRequest.offset}
+    </select>
+
+
+    <select id="countReceivedApproval" resultType="long">
+        SELECT COUNT(*)
+        FROM approve a
+        LEFT JOIN approve aa ON a.parent_approve_id = aa.approve_id
+        JOIN employee e ON a.emp_id = e.emp_id
+        JOIN department d ON e.dept_id = d.dept_id
+        JOIN status s ON a.status_id = s.status_id
+        JOIN approve_line al ON al.approve_id = a.approve_id
+        JOIN approve_line_list ali ON al.approve_line_id = ali.approve_line_id
+
+        WHERE ali.emp_id = #{empId}
+        <if test="req.tab == 'ATTENDANCE'">
+            AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
+            <if test="req.approveType != null and req.approveType != ''">
+                AND a.approve_type = #{req.approveType}
+            </if>
+        </if>
+        <if test="req.tab == 'PROPOSAL'">
+            AND a.approve_type = 'PROPOSAL'
+        </if>
+        <if test="req.tab == 'RECEIPT'">
+            AND a.approve_type = 'RECEIPT'
+            <if test="req.receiptType != null and req.receiptType != ''">
+                AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+            </if>
+        </if>
+        <if test="req.tab == 'CANCEL'">
+            AND a.approve_type = 'CANCEL'
+        </if>
+
+        <if test="req.status != null">
+            AND a.status_id = #{req.status}
+        </if>
+
+        <if test="req.title != null and req.title != ''">
+            AND a.approve_title LIKE CONCAT('%', #{req.title}, '%')
+        </if>
+
+        <if test="req.employeeName != null and req.employeeName != ''">
+            AND e.name LIKE CONCAT('%', #{req.employeeName}, '%')
+        </if>
+
+        <if test="req.startDate != null and req.endDate != null">
+            AND a.create_at BETWEEN #{req.startDate} AND #{req.endDate}
+        </if>
+        <if test="req.startDate != null and req.endDate == null">
+            AND a.create_at &gt; #{req.startDate}
+        </if>
+        <if test="req.startDate == null and req.endDate != null">
+            AND a.create_at &lt; #{req.endDate}
+        </if>
+
+        <if test="req.departmentName != null and req.departmentName != ''">
+            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        </if>
+    </select>
+
+    <!-- 존재하는 회원인지 확인하기 위한 코드 -->
+    <select id="existsByEmpId" resultType="boolean">
+        SELECT CASE WHEN EXISTS (
+            SELECT 1
+            FROM employee
+            WHERE emp_id = #{empId}
+        ) THEN TRUE ELSE FALSE END
+    </select>
+
+</mapper>

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
@@ -9,10 +9,12 @@ import com.dao.momentum.approve.query.service.ApproveService;
 import com.dao.momentum.common.dto.Pagination;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -38,8 +40,8 @@ class ApproveControllerTest {
     private List<ApproveDTO> getDummyApproves() {
         ApproveDTO dummy1 = ApproveDTO.builder()
                 .approveId(1L)
-                .approveTitle("연차 신청")
-                .approveType("OVERTIME")
+                .approveTitle("점심 비용 신청")
+                .approveType("RECEIPT")
                 .empId(1L)
                 .employeeName("장도윤")
                 .departmentName("백엔드팀")
@@ -48,8 +50,8 @@ class ApproveControllerTest {
 
         ApproveDTO dummy2 = ApproveDTO.builder()
                 .approveId(2L)
-                .approveTitle("재택근무 신청")
-                .approveType("REMOTEWORK")
+                .approveTitle("저녁 비용 신청")
+                .approveType("RECEIPT")
                 .empId(2L)
                 .employeeName("김하윤")
                 .departmentName("프론트엔드팀")
@@ -62,7 +64,7 @@ class ApproveControllerTest {
     @DisplayName("받은 결재 목록 가져오기")
     @WithMockUser(username = "1") // 임의로 인증 정보 넣기
     @Test
-    void getFollowListByMemberUidTest() throws Exception {
+    void getReceivedApprovalTest() throws Exception {
         ApproveListRequest request = ApproveListRequest.builder()
                 .tab("RECEIPT")
                 .build();
@@ -93,9 +95,6 @@ class ApproveControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.approveDTO.length").value(2))
-                .andExpect(jsonPath("$.data.approveDTO[0].approveTitle").value("연차 신청"))
-                .andExpect(jsonPath("$.data.approveDTO[1].approveTitle").value("재택근무 신청"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
@@ -1,0 +1,103 @@
+package com.dao.momentum.approve.query.controller;
+
+import com.dao.momentum.approve.query.dto.ApproveDTO;
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveResponse;
+import com.dao.momentum.approve.query.service.AdminApproveService;
+import com.dao.momentum.approve.query.service.ApproveService;
+import com.dao.momentum.common.dto.Pagination;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApproveController.class)
+@AutoConfigureMockMvc
+class ApproveControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ApproveService approveService;
+
+    private List<ApproveDTO> getDummyApproves() {
+        ApproveDTO dummy1 = ApproveDTO.builder()
+                .approveId(1L)
+                .approveTitle("연차 신청")
+                .approveType("OVERTIME")
+                .empId(1L)
+                .employeeName("장도윤")
+                .departmentName("백엔드팀")
+                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
+                .build();
+
+        ApproveDTO dummy2 = ApproveDTO.builder()
+                .approveId(2L)
+                .approveTitle("재택근무 신청")
+                .approveType("REMOTEWORK")
+                .empId(2L)
+                .employeeName("김하윤")
+                .departmentName("프론트엔드팀")
+                .createAt(LocalDateTime.of(2025, 6, 2, 0, 0))
+                .build();
+
+        return List.of(dummy1, dummy2);
+    }
+
+    @DisplayName("받은 결재 목록 가져오기")
+    @WithMockUser(username = "1") // 임의로 인증 정보 넣기
+    @Test
+    void getFollowListByMemberUidTest() throws Exception {
+        ApproveListRequest request = ApproveListRequest.builder()
+                .tab("RECEIPT")
+                .build();
+
+        Long empId = 1L;
+
+        PageRequest pageRequest = new PageRequest(1, 10);
+
+        List<ApproveDTO> dummyList = getDummyApproves();
+
+        ApproveResponse approveResponse = ApproveResponse.builder()
+                .approveDTO(dummyList)
+                .pagination(Pagination.builder()
+                        .currentPage(1)
+                        .totalPage(1)
+                        .totalItems(dummyList.size())
+                        .build())
+                .build();
+
+        Mockito.when(approveService.getReceivedApprove(request, empId, pageRequest))
+                .thenReturn(approveResponse);
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/approval/documents/received")
+                                .param("tab", "RECEIPT")
+                                .param("page", "1")
+                                .param("size", "10")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.approveDTO.length").value(2))
+                .andExpect(jsonPath("$.data.approveDTO[0].approveTitle").value("연차 신청"))
+                .andExpect(jsonPath("$.data.approveDTO[1].approveTitle").value("재택근무 신청"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+
+    }
+}

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveServiceImplTest.java
@@ -1,0 +1,115 @@
+package com.dao.momentum.approve.query.service;
+
+import com.dao.momentum.approve.exception.NotExistTabException;
+import com.dao.momentum.approve.query.dto.ApproveDTO;
+import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
+import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveResponse;
+import com.dao.momentum.approve.query.mapper.ApproveMapper;
+import com.dao.momentum.organization.employee.exception.EmployeeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import org.mockito.MockitoAnnotations;
+
+class ApproveServiceImplTest {
+
+    @Mock
+    private ApproveMapper approveMapper;
+
+    @InjectMocks
+    private ApproveServiceImpl approveService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private List<ApproveDTO> getDummyApproves() {
+        ApproveDTO dummy1 = ApproveDTO.builder()
+                .approveId(1L)
+                .approveTitle("연차 신청")
+                .approveType("OVERTIME")
+                .empId(1L)
+                .employeeName("장도윤")
+                .departmentName("백엔드팀")
+                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
+                .build();
+
+        ApproveDTO dummy2 = ApproveDTO.builder()
+                .approveId(2L)
+                .approveTitle("재택근무 신청")
+                .approveType("REMOTEWORK")
+                .empId(2L)
+                .employeeName("김하윤")
+                .departmentName("프론트엔드팀")
+                .createAt(LocalDateTime.of(2025, 6, 2, 0, 0))
+                .build();
+
+        return List.of(dummy1, dummy2);
+    }
+
+    @Test
+    @DisplayName("받은 결재 목록 조회 테스트")
+    void getReceivedApproveTest() {
+        ApproveListRequest request = ApproveListRequest.builder()
+                .tab("RECEIPT")
+                .build();
+
+        PageRequest pageRequest = new PageRequest(1, 10);
+        Long empId = 1L;
+
+        List<ApproveDTO> dummyList = getDummyApproves();
+
+        when(approveMapper.existsByEmpId(empId)).thenReturn(true);
+        when(approveMapper.findReceivedApproval(request, empId, pageRequest)).thenReturn(dummyList);
+        when(approveMapper.countReceivedApproval(request, empId)).thenReturn((long) dummyList.size());
+
+        ApproveResponse response = approveService.getReceivedApprove(request, empId, pageRequest);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getApproveDTO()).hasSize(2);
+        assertThat(response.getPagination().getTotalItems()).isEqualTo(2);
+        assertThat(response.getPagination().getTotalPage()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 탭이 들어왔을 때 예외가 발생하는 테스트")
+    void getReceivedApproveInvalidTabTest() {
+        ApproveListRequest request = ApproveListRequest.builder()
+                .tab("INVALID_TAB")
+                .build();
+
+        PageRequest pageRequest = new PageRequest(1, 10);
+        Long empId = 1L;
+
+        assertThrows(NotExistTabException.class,
+                () -> approveService.getReceivedApprove(request, empId, pageRequest));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사원 ID가 들어왔을 때 예외 발생")
+    void getReceivedApproveInvalidEmpIdTest() {
+        ApproveListRequest request = ApproveListRequest.builder()
+                .tab("RECEIPT")
+                .build();
+
+        PageRequest pageRequest = new PageRequest(1, 10);
+        Long empId = 999L;
+
+        when(approveMapper.existsByEmpId(empId)).thenReturn(false);
+
+        assertThrows(EmployeeException.class,
+                () -> approveService.getReceivedApprove(request, empId, pageRequest));
+    }
+}


### PR DESCRIPTION
closes #6

---

📌 개요
사원이 받은 결재 문서 조회 기능 구현

🔨 주요 변경 사항
- 컨트롤러 만들기
   -  `ApproveController` : /approval/documents/received 로 endpoint 설정 
   - 컨트롤러 테스트 생성
- 서비스 만들기
   - `ApproveService`, `ApproceServiceImpl` 만들기 
   - 결재 문서 조회 메서드 생성  
   - 서비스 테스트 생성 
- mapper 만들기  
   - 받은 문서 조회 메서드 생성 
   - 받은 문서 개수 구하는 메서드 생성
   - 존재하는 사원인지 확인하는 메서드 생성    

✅ 리뷰 요청 사항

⭐ 관련 이슈
#6
