### PR TITLE
[test #3, #6] 결재 내역 조회 컨트롤러, 서비스 테스트 코드 수정

### DIFF
--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveControllerTest.java
@@ -1,17 +1,14 @@
 package com.dao.momentum.approve.query.controller;
 
 import com.dao.momentum.approve.query.dto.ApproveDTO;
-import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
-import com.dao.momentum.approve.query.dto.request.PageRequest;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.service.AdminApproveService;
 import com.dao.momentum.common.dto.Pagination;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -26,11 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminApproveController.class)
-@AutoConfigureMockMvc
 class AdminApproveControllerTest {
 
     @Autowired
     MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     AdminApproveService adminApproveService;
@@ -39,10 +38,10 @@ class AdminApproveControllerTest {
         ApproveDTO dummy1 = ApproveDTO.builder()
                 .approveId(1L)
                 .parentApproveId(null)
-                .statusType("RECEIPT")
+                .statusType("ACCEPTED")
                 .empId(1L)
-                .approveTitle("연차 신청")
-                .approveType("OVERTIME")
+                .approveTitle("점심 식사 영수증")
+                .approveType("RECEIPT")
                 .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .completeAt(null)
                 .employeeName("장도윤")
@@ -52,10 +51,10 @@ class AdminApproveControllerTest {
         ApproveDTO dummy2 = ApproveDTO.builder()
                 .approveId(2L)
                 .parentApproveId(null)
-                .statusType("RECEIPT")
+                .statusType("ACCEPTED")
                 .empId(2L)
-                .approveTitle("프로젝트 제안서 제출")
-                .approveType("REMOTEWORK")
+                .approveTitle("출장 택시비")
+                .approveType("RECEIPT")
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
@@ -71,13 +70,6 @@ class AdminApproveControllerTest {
     @WithMockUser(authorities = "MASTER")
     @Test
     void getFollowListByMemberUidTest() throws Exception {
-
-        ApproveListRequest request = ApproveListRequest.builder()
-                .tab("RECEIPT")
-                .build();
-
-        PageRequest pageRequest = new PageRequest(1, 10);
-
         List<ApproveDTO> dummyList = getDummyApproves();
 
         ApproveResponse approveResponse = ApproveResponse.builder()
@@ -89,8 +81,10 @@ class AdminApproveControllerTest {
                         .build())
                 .build();
 
-        Mockito.when(adminApproveService.getApproveList(request, pageRequest))
+        Mockito.when(adminApproveService.getApproveList(Mockito.any(), Mockito.any()))
                 .thenReturn(approveResponse);
+
+        System.out.println(approveResponse);
 
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/admin/approval/documents")
@@ -100,6 +94,8 @@ class AdminApproveControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.approveDTO[0].approveTitle").value("점심 식사 영수증"))
+                .andExpect(jsonPath("$.data.approveDTO[1].approveTitle").value("출장 택시비"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveControllerTest.java
@@ -1,20 +1,15 @@
 package com.dao.momentum.approve.query.controller;
 
 import com.dao.momentum.approve.query.dto.ApproveDTO;
-import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
-import com.dao.momentum.approve.query.dto.request.PageRequest;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
-import com.dao.momentum.approve.query.service.AdminApproveService;
 import com.dao.momentum.approve.query.service.ApproveService;
 import com.dao.momentum.common.dto.Pagination;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,22 +35,28 @@ class ApproveControllerTest {
     private List<ApproveDTO> getDummyApproves() {
         ApproveDTO dummy1 = ApproveDTO.builder()
                 .approveId(1L)
-                .approveTitle("점심 비용 신청")
-                .approveType("RECEIPT")
+                .parentApproveId(null)
+                .statusType("ACCEPTED")
                 .empId(1L)
+                .approveTitle("점심 식사 영수증")
+                .approveType("RECEIPT")
+                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
+                .completeAt(null)
                 .employeeName("장도윤")
                 .departmentName("백엔드팀")
-                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .build();
 
         ApproveDTO dummy2 = ApproveDTO.builder()
                 .approveId(2L)
-                .approveTitle("저녁 비용 신청")
-                .approveType("RECEIPT")
+                .parentApproveId(null)
+                .statusType("ACCEPTED")
                 .empId(2L)
+                .approveTitle("출장 택시비")
+                .approveType("RECEIPT")
+                .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
+                .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
                 .departmentName("프론트엔드팀")
-                .createAt(LocalDateTime.of(2025, 6, 2, 0, 0))
                 .build();
 
         return List.of(dummy1, dummy2);
@@ -65,13 +66,6 @@ class ApproveControllerTest {
     @WithMockUser(username = "1") // 임의로 인증 정보 넣기
     @Test
     void getReceivedApprovalTest() throws Exception {
-        ApproveListRequest request = ApproveListRequest.builder()
-                .tab("RECEIPT")
-                .build();
-
-        Long empId = 1L;
-
-        PageRequest pageRequest = new PageRequest(1, 10);
 
         List<ApproveDTO> dummyList = getDummyApproves();
 
@@ -84,7 +78,7 @@ class ApproveControllerTest {
                         .build())
                 .build();
 
-        Mockito.when(approveService.getReceivedApprove(request, empId, pageRequest))
+        Mockito.when(approveService.getReceivedApprove(Mockito.any(), Mockito.any() ,Mockito.any()))
                 .thenReturn(approveResponse);
 
         mockMvc.perform(
@@ -95,6 +89,8 @@ class ApproveControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.approveDTO[0].approveTitle").value("점심 식사 영수증"))
+                .andExpect(jsonPath("$.data.approveDTO[1].approveTitle").value("출장 택시비"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveServiceImplTest.java
@@ -37,10 +37,10 @@ class AdminApproveServiceImplTest {
         ApproveDTO dummy1 = ApproveDTO.builder()
                 .approveId(1L)
                 .parentApproveId(null)
-                .statusType("RECEIPT")
+                .statusType("ACCEPTED")
                 .empId(1L)
-                .approveTitle("연차 신청")
-                .approveType("OVERTIME")
+                .approveTitle("점심 식사 영수증")
+                .approveType("RECEIPT")
                 .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .completeAt(null)
                 .employeeName("장도윤")
@@ -50,10 +50,10 @@ class AdminApproveServiceImplTest {
         ApproveDTO dummy2 = ApproveDTO.builder()
                 .approveId(2L)
                 .parentApproveId(null)
-                .statusType("RECEIPT")
+                .statusType("ACCEPTED")
                 .empId(2L)
-                .approveTitle("프로젝트 제안서 제출")
-                .approveType("REMOTEWORK")
+                .approveTitle("출장 택시비")
+                .approveType("RECEIPT")
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
@@ -82,8 +82,8 @@ class AdminApproveServiceImplTest {
         ApproveResponse result = adminApproveService.getApproveList(request, pageRequest);
 
         assertThat(result).isNotNull();
-        assertThat(result.getApproveDTO().get(0).getApproveTitle()).isEqualTo("연차 신청");
-        assertThat(result.getApproveDTO().get(1).getApproveType()).isEqualTo("REMOTEWORK");
+        assertThat(result.getApproveDTO().get(0).getApproveTitle()).isEqualTo("점심 식사 영수증");
+        assertThat(result.getApproveDTO().get(1).getApproveType()).isEqualTo("RECEIPT");
 
         verify(adminApproveMapper, times(1)).findAllApproval(any(), any());
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveServiceImplTest.java
@@ -38,23 +38,30 @@ class ApproveServiceImplTest {
     private List<ApproveDTO> getDummyApproves() {
         ApproveDTO dummy1 = ApproveDTO.builder()
                 .approveId(1L)
-                .approveTitle("연차 신청")
-                .approveType("OVERTIME")
+                .parentApproveId(null)
+                .statusType("ACCEPTED")
                 .empId(1L)
+                .approveTitle("점심 식사 영수증")
+                .approveType("RECEIPT")
+                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
+                .completeAt(null)
                 .employeeName("장도윤")
                 .departmentName("백엔드팀")
-                .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .build();
 
         ApproveDTO dummy2 = ApproveDTO.builder()
                 .approveId(2L)
-                .approveTitle("재택근무 신청")
-                .approveType("REMOTEWORK")
+                .parentApproveId(null)
+                .statusType("ACCEPTED")
                 .empId(2L)
+                .approveTitle("출장 택시비")
+                .approveType("RECEIPT")
+                .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
+                .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
                 .departmentName("프론트엔드팀")
-                .createAt(LocalDateTime.of(2025, 6, 2, 0, 0))
                 .build();
+
 
         return List.of(dummy1, dummy2);
     }


### PR DESCRIPTION
closes #3 , #6 
---

📌 개요
결재 내역 조회 컨트롤러, 서비스 테스트 코드 수정

🔨 주요 변경 사항
- 잘못된 더미 데이터 수정하기
- 컨틀롤러 테스트에서 모의 객체에게 매개변수를 넘길 때, `Mockito.any()`로 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#3 , #6
