### PR TITLE
feat: 직위 수정 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager">
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="8cc95f56-778b-49c8-a66a-38c40b793d1a" name="변경" comment="" />
+    <list default="true" id="8cc95f56-778b-49c8-a66a-38c40b793d1a" name="변경" comment="">
+      <change afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/request/PositionUpdateRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/response/PositionUpdateResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java" beforeDir="false" afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/service/PositionCommandService.java" beforeDir="false" afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/service/PositionCommandService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java" beforeDir="false" afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -10,44 +20,36 @@
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "meowdule"
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;meowdule&quot;
   }
-}]]></component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/be15-fin-project/be15-fin-BE.git",
-    "accountId": "c82c5e19-6da9-4a60-8e60-9611125cc815"
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/be15-fin-project/be15-fin-BE.git&quot;,
+    &quot;accountId&quot;: &quot;c82c5e19-6da9-4a60-8e60-9611125cc815&quot;
   }
-}]]></component>
-  <component name="ProjectColorInfo"><![CDATA[{
-  "associatedIndex": 2
-}]]></component>
+}</component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 2
+}</component>
   <component name="ProjectId" id="2yQlVF5rrqk3EnndnbiSqJSdQ38" />
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "entity/evaluation",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/develop/be15_project/be15-fin-DAO-Momentum/fin-BE/momentum-dao-be",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/organization/position&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/develop/be15_project/be15-fin-DAO-Momentum/fin-BE/momentum-dao-be&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
-  <component name="SharedIndexes">
-    <attachedChunks>
-      <set>
-        <option value="bundled-jdk-9823dce3aa75-a94e463ab2e7-intellij.indexing.shared.core-IU-243.26053.27" />
-        <option value="bundled-js-predefined-d6986cc7102b-1632447f56bf-JavaScript-IU-243.26053.27" />
-      </set>
-    </attachedChunks>
-  </component>
+}</component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="애플리케이션 수준" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="디폴트 작업">
@@ -57,6 +59,8 @@
       <option name="presentableId" value="Default" />
       <updated>1749774700018</updated>
       <workItem from="1749774701134" duration="76000" />
+      <workItem from="1750119479837" duration="212000" />
+      <workItem from="1750119729506" duration="82000" />
     </task>
     <servers />
   </component>

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                               permitAllEndpoints(auth);
 //                            employeeEndpoints(auth);
 //                            managerEndpoints(auth);
-//                            masterEndpoints(auth);
+                              masterEndpoints(auth);
 //                            hrManagerEndpoints(auth);
 //                            bookkeepingEndpoints(auth);
 
@@ -112,7 +112,7 @@ public class SecurityConfig {
     // 마스터 관리자 전용
     private void masterEndpoints(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
-                "/employees"
+                "/position"
         ).hasAuthority("MASTER");
     }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -11,8 +11,9 @@ public enum ErrorCode {
     //사원 오류(10001 - 199999)
     EMPLOYEE_ALREADY_EXISTS("10001", "해당 사원이 이미 존재합니다.",HttpStatus.BAD_REQUEST),
     EMPLOYEE_NOT_FOUND("10002","해당 사원을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
-    INVALID_CREDENTIALS("10003","유효하지 않은 입력입니다. 다시 입력해주세요",HttpStatus.FORBIDDEN),
-    POSITION_ALREADY_EXISTS("10004","이미 존재하는 직위입니다.",HttpStatus.FORBIDDEN),
+    INVALID_CREDENTIALS("10003","유효하지 않은 입력입니다. 다시 입력해주세요",HttpStatus.NOT_FOUND),
+    POSITION_ALREADY_EXISTS("10004","이미 존재하는 직위입니다.",HttpStatus.CONFLICT),
+    POSITION_NOT_FOUND("10005","존재하지 않는 직위입니다.",HttpStatus.NOT_FOUND),
 
     // 출퇴근 오류
     WORKTYPE_NOT_FOUND("20001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -9,11 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum ErrorCode {
     //사원 오류(10001 - 199999)
-    EMPLOYEE_ALREADY_EXISTS("10001", "해당 사원이 이미 존재합니다.",HttpStatus.BAD_REQUEST),
+    EMPLOYEE_ALREADY_EXISTS("10001", "해당 사원이 이미 존재합니다.",HttpStatus.CONFLICT),
     EMPLOYEE_NOT_FOUND("10002","해당 사원을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
     INVALID_CREDENTIALS("10003","유효하지 않은 입력입니다. 다시 입력해주세요",HttpStatus.NOT_FOUND),
     POSITION_ALREADY_EXISTS("10004","이미 존재하는 직위입니다.",HttpStatus.CONFLICT),
     POSITION_NOT_FOUND("10005","존재하지 않는 직위입니다.",HttpStatus.NOT_FOUND),
+    INVALID_LEVEL("10006","유효하지 않은 직위 단계입니다." , HttpStatus.BAD_REQUEST),
 
     // 출퇴근 오류
     WORKTYPE_NOT_FOUND("20001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java
@@ -2,7 +2,9 @@ package com.dao.momentum.organization.position.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.organization.position.command.application.dto.request.PositionCreateRequest;
+import com.dao.momentum.organization.position.command.application.dto.request.PositionUpdateRequest;
 import com.dao.momentum.organization.position.command.application.dto.response.PositionCreateResponse;
+import com.dao.momentum.organization.position.command.application.dto.response.PositionUpdateResponse;
 import com.dao.momentum.organization.position.command.application.service.PositionCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -21,9 +24,16 @@ public class PositionCommandController {
 
     @Operation(summary = "직위 생성", description = "관리자는 회사의 직위를 생성할 수 있다.")
     @PostMapping
-    public ResponseEntity<ApiResponse<PositionCreateResponse>> createPositions(@RequestBody PositionCreateRequest request){
+    public ResponseEntity<ApiResponse<PositionCreateResponse>> createPosition(@RequestBody PositionCreateRequest request){
         PositionCreateResponse positionsResponse = positionService.createPositions(request);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(positionsResponse));
+    }
+
+    @Operation(summary = "직위 수정", description = "관리자는 회사의 직위를 수정할 수 있다.")
+    @PutMapping
+    public ResponseEntity<ApiResponse<PositionUpdateResponse>> updatePosition(@RequestBody PositionUpdateRequest request){
+        PositionUpdateResponse response = positionService.updatePosition(request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/request/PositionUpdateRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/request/PositionUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.organization.position.command.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PositionUpdateRequest {
+    @NotNull
+    private Integer positionId;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private Integer level;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/response/PositionUpdateResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/response/PositionUpdateResponse.java
@@ -1,0 +1,13 @@
+package com.dao.momentum.organization.position.command.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PositionUpdateResponse {
+    private Integer positionId;
+    private String message;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/service/PositionCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/service/PositionCommandService.java
@@ -2,17 +2,21 @@ package com.dao.momentum.organization.position.command.application.service;
 
 import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.organization.position.command.application.dto.request.PositionCreateRequest;
+import com.dao.momentum.organization.position.command.application.dto.request.PositionUpdateRequest;
 import com.dao.momentum.organization.position.command.application.dto.response.PositionCreateResponse;
+import com.dao.momentum.organization.position.command.application.dto.response.PositionUpdateResponse;
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import com.dao.momentum.organization.position.command.domain.repository.PositionRepository;
 import com.dao.momentum.organization.position.exception.PositionException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PositionCommandService {
     private final PositionRepository positionRepository;
     private final ModelMapper modelMapper;
@@ -23,8 +27,10 @@ public class PositionCommandService {
             throw new PositionException(ErrorCode.POSITION_ALREADY_EXISTS);
         }
 
-        //POSITION_ALREADY_EXISTS
         Integer requestedLevel = request.getLevel();
+
+        //직위 단계 범위검사
+        validateLevelForCreate(requestedLevel);
 
         // 이미 존재하는 레벨인지 확인
         boolean levelExists = positionRepository.existsByLevel(requestedLevel);
@@ -36,6 +42,56 @@ public class PositionCommandService {
         Position position = modelMapper.map(request, Position.class);
         positionRepository.save(position);
 
+
         return new PositionCreateResponse(position.getPositionId(), "직위가 생성되었습니다.");
+    }
+
+    @Transactional
+    public PositionUpdateResponse updatePosition(PositionUpdateRequest request) {
+        Integer requestedLevel = request.getLevel();
+
+        //직위 단계 범위검사
+        validateLevelForUpdate(requestedLevel);
+
+        //직위 존재 검사
+        Position position = positionRepository.findByPositionId(request.getPositionId()).orElseThrow(
+                () ->  new PositionException(ErrorCode.POSITION_NOT_FOUND)
+        );
+
+        //직위명 검사
+        if(!position.getName().equals(request.getName()) && positionRepository.existsByName(request.getName())){
+            throw new PositionException(ErrorCode.POSITION_ALREADY_EXISTS);
+        }
+
+        //직위 단계 조정
+        if(position.getLevel()>requestedLevel){
+            positionRepository.incrementLevelsInRange(requestedLevel, position.getLevel()-1);
+        }
+        else if(position.getLevel() < requestedLevel){
+            positionRepository.decrementLevelsInRange(position.getLevel()+1, requestedLevel);
+        }
+
+        position.setName(request.getName());
+
+        position.setLevel(requestedLevel);
+
+        return new PositionUpdateResponse(position.getPositionId(), "직위가 수정되었습니다.");
+    }
+
+    private void validateLevelForCreate(int requestLevel) {
+        Integer maxLevel = positionRepository.findMaxLevel();
+        if (maxLevel == null) maxLevel = 0;
+
+        if (requestLevel < 1 || requestLevel > maxLevel + 1) {
+            throw new PositionException(ErrorCode.INVALID_LEVEL);
+        }
+    }
+
+    private void validateLevelForUpdate(int requestLevel) {
+        Integer maxLevel = positionRepository.findMaxLevel();
+
+        if (maxLevel == null || requestLevel < 1 || requestLevel > maxLevel) {
+            throw new PositionException(ErrorCode.INVALID_LEVEL);
+        }
     }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java
@@ -2,16 +2,16 @@ package com.dao.momentum.organization.position.command.domain.aggregate;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 @Table(name = "`position`")
+@Builder
 public class Position {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
@@ -2,6 +2,9 @@ package com.dao.momentum.organization.position.command.domain.repository;
 
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 public interface PositionRepository {
     boolean existsByName(@NotBlank String name);
@@ -11,4 +14,12 @@ public interface PositionRepository {
     boolean existsByLevel(Integer requestedLevel);
 
     void incrementLevelsGreaterThanEqual(Integer requestedLevel);
+
+    Optional<Position> findByPositionId(@NotNull Integer positionId);
+
+    Integer findMaxLevel();
+
+    void incrementLevelsInRange(int startLevel, int endLevel);
+
+    void decrementLevelsInRange(int startLevel, int endLevel);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface JpaPositionRepository extends PositionRepository, JpaRepository<Position, Integer> {
     @Override
     boolean existsByName(String name);
@@ -21,4 +23,19 @@ public interface JpaPositionRepository extends PositionRepository, JpaRepository
     @Query("UPDATE Position p SET p.level = p.level + 1 WHERE p.level >= :level AND p.isDeleted = 'N'")
     void incrementLevelsGreaterThanEqual(@Param("level") Integer level);
 
+    @Override
+    Optional<Position> findByPositionId(Integer positionId);
+
+    @Query("SELECT MAX(p.level) FROM Position p WHERE p.isDeleted = 'N'")
+    Integer findMaxLevel();
+
+    @Modifying
+    @Query("UPDATE Position p SET p.level = p.level + 1 " +
+            "WHERE p.level BETWEEN :startLevel AND :endLevel AND p.isDeleted = 'N'")
+    void incrementLevelsInRange(@Param("startLevel") int startLevel, @Param("endLevel") int endLevel);
+
+    @Modifying
+    @Query("UPDATE Position p SET p.level = p.level - 1 " +
+            "WHERE p.level BETWEEN :startLevel AND :endLevel AND p.isDeleted = 'N'")
+    void decrementLevelsInRange(@Param("startLevel") int startLevel, @Param("endLevel") int endLevel);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/exception/PositionException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/exception/PositionException.java
@@ -1,7 +1,9 @@
 package com.dao.momentum.organization.position.exception;
 
 import com.dao.momentum.common.exception.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class PositionException extends RuntimeException{
     private final ErrorCode errorCode;
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/organization/position/command/application/service/PositionCommandServiceTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/organization/position/command/application/service/PositionCommandServiceTest.java
@@ -2,13 +2,18 @@ package com.dao.momentum.organization.position.command.application.service;
 
 import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.organization.position.command.application.dto.request.PositionCreateRequest;
+import com.dao.momentum.organization.position.command.application.dto.request.PositionUpdateRequest;
 import com.dao.momentum.organization.position.command.application.dto.response.PositionCreateResponse;
+import com.dao.momentum.organization.position.command.application.dto.response.PositionUpdateResponse;
+import com.dao.momentum.organization.position.command.domain.aggregate.IsDeleted;
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import com.dao.momentum.organization.position.command.domain.repository.PositionRepository;
 import com.dao.momentum.organization.position.exception.PositionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -70,6 +75,7 @@ class PositionCommandServiceTest {
 
         when(positionRepository.existsByName("CEO")).thenReturn(false);
         when(positionRepository.existsByLevel(10)).thenReturn(false);
+        when(positionRepository.findMaxLevel()).thenReturn(9);
 
         // when
         PositionCreateResponse response = positionCommandService.createPositions(request);
@@ -80,4 +86,81 @@ class PositionCommandServiceTest {
 
         assertThat(response.getMessage()).isEqualTo("직위가 생성되었습니다.");
     }
+
+    //직위 수정시 정상 수정
+    @Test
+    void shouldUpdatePosition_WhenInputIsValid() {
+        // given
+        Integer positionId = 1;
+        Position originalPosition = new Position(positionId, "Developer", 3, IsDeleted.N);
+        PositionUpdateRequest request = new PositionUpdateRequest(positionId, "Team Leader", 2);
+
+        when(positionRepository.findByPositionId(positionId)).thenReturn(Optional.of(originalPosition));
+        when(positionRepository.existsByName("Team Leader")).thenReturn(false);
+        when(positionRepository.findMaxLevel()).thenReturn(5);
+
+        // when
+        PositionUpdateResponse response = positionCommandService.updatePosition(request);
+
+        // then
+        assertEquals(positionId, response.getPositionId());
+        assertEquals("직위가 수정되었습니다.", response.getMessage());
+        assertEquals("Team Leader", originalPosition.getName());
+        assertEquals(2, originalPosition.getLevel());
+
+        verify(positionRepository).incrementLevelsInRange(2, 2);
+    }
+
+    //직위가 없을 시 예외처리
+    @Test
+    void shouldThrowException_WhenPositionNotFound() {
+        // given
+        Integer positionId = 11;
+        PositionUpdateRequest request = new PositionUpdateRequest(positionId, "Team Leader", 2);
+
+        when(positionRepository.findMaxLevel()).thenReturn(10);
+        when(positionRepository.findByPositionId(positionId)).thenReturn(Optional.empty());
+
+        // then
+        PositionException exception = assertThrows(PositionException.class, () ->
+                positionCommandService.updatePosition(request));
+
+        assertEquals(ErrorCode.POSITION_NOT_FOUND, exception.getErrorCode());
+    }
+
+    //이름이 이미 존재한다면 예외처리
+    @Test
+    void shouldThrowException_WhenNameAlreadyExists() {
+        // given
+        Integer positionId = 1;
+        Position originalPosition = new Position(positionId, "Developer", 3, IsDeleted.N);
+        PositionUpdateRequest request = new PositionUpdateRequest(positionId, "Manager", 3);
+
+        when(positionRepository.findByPositionId(positionId)).thenReturn(Optional.of(originalPosition));
+        when(positionRepository.existsByName("Manager")).thenReturn(true);
+        when(positionRepository.findMaxLevel()).thenReturn(5);
+
+        // then
+        PositionException exception = assertThrows(PositionException.class, () ->
+                positionCommandService.updatePosition(request));
+
+        assertEquals(ErrorCode.POSITION_ALREADY_EXISTS, exception.getErrorCode());
+    }
+
+    //직위가 범위를 벗어났다면 예외처리
+    @Test
+    void shouldThrowException_WhenRequestedLevelOutOfRange() {
+        // given
+        Integer positionId = 1;
+        PositionUpdateRequest request = new PositionUpdateRequest(positionId, "Developer", 10);
+
+        when(positionRepository.findMaxLevel()).thenReturn(5);
+
+        // then
+        PositionException exception = assertThrows(PositionException.class, () ->
+                positionCommandService.updatePosition(request));
+
+        assertEquals(ErrorCode.INVALID_LEVEL, exception.getErrorCode());
+    }
+
 }


### PR DESCRIPTION
closes #102 

---

📌 개요
- 직위 변경 시 직위명, 직위 단계, 직위 원본 존재여부를 확인 한 후 직위를 변경한다.
- 해당 직위 단계 변경시 다른 직위의 단계를 조정한다.
- 마스터 관리자만 직위를 수정할 수 있다.

🔨 주요 변경 사항
- PositionCommandController 및 PositionCommandService 메소드 구현
- 직위 변경 테스트코드 작성
- securityConfig 마스터 관리자 엔트포인트 추가

✅ 리뷰 요청 사항
- 직위 수정 기능 로직 확인
- 테스트코드 로직 확인

⭐ 관련 이슈
#102
