### PR TITLE
feat: 직위 삭제 기능 구현 및 테스트코드 작성

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -112,7 +112,8 @@ public class SecurityConfig {
     // 마스터 관리자 전용
     private void masterEndpoints(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
-                "/position"
+                "/position",
+                "/position/**"
         ).hasAuthority("MASTER");
     }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     POSITION_ALREADY_EXISTS("10004","이미 존재하는 직위입니다.",HttpStatus.CONFLICT),
     POSITION_NOT_FOUND("10005","존재하지 않는 직위입니다.",HttpStatus.NOT_FOUND),
     INVALID_LEVEL("10006","유효하지 않은 직위 단계입니다." , HttpStatus.BAD_REQUEST),
+    POSITION_IN_USE("10007","해당 직위인 사원이 존재합니다." ,HttpStatus.CONFLICT ),
 
     // 출퇴근 오류
     WORKTYPE_NOT_FOUND("20001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/repository/EmployeeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/repository/EmployeeRepository.java
@@ -12,4 +12,6 @@ public interface EmployeeRepository {
     Optional<Employee> findByEmpId(Long empId);
 
     String findMaxEmpNo();
+
+    Boolean existsByPositionId(Integer positionId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/infrastructure/repository/JpaEmployeeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/infrastructure/repository/JpaEmployeeRepository.java
@@ -19,4 +19,6 @@ public interface JpaEmployeeRepository extends EmployeeRepository, JpaRepository
             "ORDER BY CAST(emp_no AS UNSIGNED) DESC LIMIT 1",
             nativeQuery = true)
     String findMaxEmpNo();
+
+    Boolean existsByPositionId(Integer positionId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/controller/PositionCommandController.java
@@ -4,6 +4,7 @@ import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.organization.position.command.application.dto.request.PositionCreateRequest;
 import com.dao.momentum.organization.position.command.application.dto.request.PositionUpdateRequest;
 import com.dao.momentum.organization.position.command.application.dto.response.PositionCreateResponse;
+import com.dao.momentum.organization.position.command.application.dto.response.PositionDeleteResponse;
 import com.dao.momentum.organization.position.command.application.dto.response.PositionUpdateResponse;
 import com.dao.momentum.organization.position.command.application.service.PositionCommandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -33,6 +31,13 @@ public class PositionCommandController {
     @PutMapping
     public ResponseEntity<ApiResponse<PositionUpdateResponse>> updatePosition(@RequestBody PositionUpdateRequest request){
         PositionUpdateResponse response = positionService.updatePosition(request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "직위 삭제", description = "관리자는 회사의 직위를 삭제할 수 있다.")
+    @DeleteMapping("/{positionId}")
+    public ResponseEntity<ApiResponse<PositionDeleteResponse>> deletePosition(@PathVariable Integer positionId){
+        PositionDeleteResponse response = positionService.deletePosition(positionId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/response/PositionDeleteResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/application/dto/response/PositionDeleteResponse.java
@@ -1,0 +1,13 @@
+package com.dao.momentum.organization.position.command.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PositionDeleteResponse {
+    private Integer positionId;
+    private String message;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/aggregate/Position.java
@@ -3,6 +3,7 @@ package com.dao.momentum.organization.position.command.domain.aggregate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
@@ -12,6 +13,7 @@ import lombok.*;
 @ToString
 @Table(name = "`position`")
 @Builder
+@SQLDelete(sql = "update `position` set is_deleted = 'Y' where position_id = ?")
 public class Position {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
@@ -3,6 +3,7 @@ package com.dao.momentum.organization.position.command.domain.repository;
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -15,11 +16,15 @@ public interface PositionRepository {
 
     void incrementLevelsGreaterThanEqual(Integer requestedLevel);
 
-    Optional<Position> findByPositionId(@NotNull Integer positionId);
+    void decrementLevelsGreater(Integer level);
+
+    Optional<Position> findByPositionId( Integer positionId);
 
     Integer findMaxLevel();
 
     void incrementLevelsInRange(int startLevel, int endLevel);
 
     void decrementLevelsInRange(int startLevel, int endLevel);
+
+    void deleteByPositionId(Integer positionId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/infrastructure/repository/JpaPositionRepository.java
@@ -23,6 +23,10 @@ public interface JpaPositionRepository extends PositionRepository, JpaRepository
     @Query("UPDATE Position p SET p.level = p.level + 1 WHERE p.level >= :level AND p.isDeleted = 'N'")
     void incrementLevelsGreaterThanEqual(@Param("level") Integer level);
 
+    @Modifying
+    @Query("UPDATE Position p SET p.level = p.level - 1 WHERE p.level > :level AND p.isDeleted = 'N'")
+    void decrementLevelsGreater(@Param("level") Integer level);
+
     @Override
     Optional<Position> findByPositionId(Integer positionId);
 
@@ -38,4 +42,6 @@ public interface JpaPositionRepository extends PositionRepository, JpaRepository
     @Query("UPDATE Position p SET p.level = p.level - 1 " +
             "WHERE p.level BETWEEN :startLevel AND :endLevel AND p.isDeleted = 'N'")
     void decrementLevelsInRange(@Param("startLevel") int startLevel, @Param("endLevel") int endLevel);
+
+    void deleteByPositionId(Integer positionId);
 }


### PR DESCRIPTION
closes #103 

---

📌 개요
직위 삭제 기능 구현 및 테스트코드 작성

🔨 주요 변경 사항
- PositionCommandController, PositionCommandService 직위 삭제 메소드 구현
- 직위 삭제시 직위 존재, 해당 직위인 사원 검사 및 다른 직위 단계 조정
- 직위 삭제 테스트 코드 작성 

✅ 리뷰 요청 사항

⭐ 관련 이슈
#103 
