### PR TITLE
feat: 공지사항 삭제 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandController.java
@@ -54,6 +54,17 @@ public class AnnouncementCommandController {
                 .ok(ApiResponse.success(announcementModifyResponse));
     }
 
+    @DeleteMapping("{announcementId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAnnouncement(
+            @PathVariable("announcementId") Long announcementId,
+            @AuthenticationPrincipal UserDetails userDetails)
+    {
+        announcementCommandService.delete(announcementId, userDetails);
+
+        return ResponseEntity
+                .ok(ApiResponse.success(null));
+    }
+
     @ExceptionHandler(AnnouncementAccessDeniedException.class)
     public ResponseEntity<ApiResponse<Void>> handleAnnouncementAccessDeniedException(AnnouncementAccessDeniedException e) {
         ErrorCode errorCode = e.getErrorCode();

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
@@ -153,7 +153,10 @@ public class AnnouncementCommandService {
 
         // 공지사항에 첨부된 파일들 hard delete
         List<File> files = fileRepository.findAllByAnnouncementId(announcementId);
-        files.forEach(file -> fileRepository.deleteById(file.getAttachmentId()));
+        files.forEach(file -> {
+            s3Service.deleteFileFromS3(file.getUrl());
+            fileRepository.deleteById(file.getAttachmentId());
+        });
 
         log.info("공지사항 삭제 - empId={}, announcementId={}, title={}", empId, announcement.getAnnouncementId(), announcement.getTitle());
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/Announcement.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/Announcement.java
@@ -5,6 +5,7 @@ import com.dao.momentum.common.exception.ErrorCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE announcement SET is_deleted = true WHERE announcement_id = ?")
 @EntityListeners(AuditingEntityListener.class)
 public class Announcement {
     @Id

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/repository/AnnouncementRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/repository/AnnouncementRepository.java
@@ -9,5 +9,5 @@ public interface AnnouncementRepository {
 
     Optional<Announcement> findById(Long announcementId);
 
-    void deleteById(Long announcementId);
+    void delete(Announcement announcement);
 }

--- a/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandControllerTest.java
@@ -14,18 +14,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AnnouncementCommandController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@WithMockUser(username = "123")
 class AnnouncementCommandControllerTest {
 
     @Autowired
@@ -52,7 +56,7 @@ class AnnouncementCommandControllerTest {
                 "files", "test.txt", "text/plain", "내용".getBytes());
 
         AnnouncementCreateResponse response = new AnnouncementCreateResponse(1L);
-        when(announcementCommandService.create(any(), any(), any())).thenReturn(response);
+        when(announcementCommandService.create(any(), any(), any(UserDetails.class))).thenReturn(response);
 
         // when & then
         mockMvc.perform(multipart("/announcement")
@@ -72,7 +76,7 @@ class AnnouncementCommandControllerTest {
         request.setRemainFileIdList(List.of(1L, 2L));
 
         AnnouncementModifyResponse response = new AnnouncementModifyResponse(1L);
-        when(announcementCommandService.modify(any(), any(), eq(1L), any())).thenReturn(response);
+        when(announcementCommandService.modify(any(), any(), eq(1L), any(UserDetails.class))).thenReturn(response);
 
         MockMultipartFile jsonPart = new MockMultipartFile(
                 "announcement", null, "application/json", objectMapper.writeValueAsBytes(request));
@@ -89,13 +93,30 @@ class AnnouncementCommandControllerTest {
     }
 
     @Test
-    @DisplayName("공지사항이 존재하지 않으면 404")
+    @DisplayName("공지사항 삭제 성공")
+    void testDeleteAnnouncement() throws Exception {
+        // given
+        Long announcementId = 1L;
+
+        doNothing().when(announcementCommandService).delete(eq(announcementId), any(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(delete("/announcement/{announcementId}", announcementId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(announcementCommandService).delete(eq(announcementId), any(UserDetails.class));
+    }
+
+    @Test
+    @DisplayName("공지사항 수정 - 공지사항이 존재하지 않으면 404")
     void testModifyAnnouncement_NotFound() throws Exception {
         AnnouncementModifyRequest request = new AnnouncementModifyRequest();
         request.setTitle("제목");
         request.setContent("내용");
 
-        when(announcementCommandService.modify(any(), any(), eq(999L), any()))
+        when(announcementCommandService.modify(any(), any(), eq(999L), any(UserDetails.class)))
                 .thenThrow(new NoSuchAnnouncementException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
 
         MockMultipartFile jsonPart = new MockMultipartFile(


### PR DESCRIPTION
closes #73 

---

📌 개요
공지사항 삭제 기능 구현

🔨 주요 변경 사항
- 공지사항 삭제 기능 구현 및 테스트 코드 작성
- 공지사항 삭제 시 관련 첨부 파일 영구 삭제 로직 구현 

⭐ 관련 이슈
#73 
