### PR TITLE
refactor : 클래스명 변경 (Query 추가)

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/AdminApproveQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/AdminApproveQueryController.java
@@ -3,17 +3,13 @@ package com.dao.momentum.approve.query.controller;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
-import com.dao.momentum.approve.query.service.AdminApproveService;
+import com.dao.momentum.approve.query.service.AdminApproveQueryService;
 import com.dao.momentum.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.tags.Tags;
-import jakarta.persistence.Table;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,9 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin")
 @Tag(name = "전체 결재 내역 조회", description = "전체 결재 내역 조회 API")
 @RequiredArgsConstructor
-public class AdminApproveController {
+public class AdminApproveQueryController {
 
-    private final AdminApproveService adminApproveService;
+    private final AdminApproveQueryService adminApproveQueryService;
 
     /* 전체 결재 목록 조회하기 */
     @GetMapping("/approval/documents")
@@ -37,7 +33,7 @@ public class AdminApproveController {
     ) {
 
         ApproveResponse approveResponse
-                = adminApproveService.getApproveList(approveListRequest, pageRequest);
+                = adminApproveQueryService.getApproveList(approveListRequest, pageRequest);
 
         return ResponseEntity.ok(ApiResponse.success(approveResponse));
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ReceivedApproveMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ReceivedApproveMapper.java
@@ -9,7 +9,7 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 @Mapper
-public interface ApproveMapper {
+public interface ReceivedApproveMapper {
 
     List<ApproveDTO> findReceivedApproval(
             @Param("req") ApproveListRequest approveListRequest,

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/AdminApproveQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/AdminApproveQueryService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 
 @Service
-public interface AdminApproveService {
+public interface AdminApproveQueryService {
 
     ApproveResponse getApproveList(
             ApproveListRequest approveListRequest,

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class AdminApproveServiceImpl implements AdminApproveService {
+public class AdminApproveQueryServiceImpl implements AdminApproveQueryService {
 
     private final AdminApproveMapper adminApproveMapper;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
@@ -8,7 +8,7 @@ import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
-import com.dao.momentum.approve.query.mapper.ApproveMapper;
+import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.common.dto.Pagination;
 import com.dao.momentum.common.exception.ErrorCode;
@@ -25,7 +25,7 @@ import java.util.List;
 @Slf4j
 public class ApproveQueryServiceImpl implements ApproveQueryService {
 
-    private final ApproveMapper approveMapper;
+    private final ReceivedApproveMapper receivedApproveMapper;
     private final DraftApproveMapper draftApproveMapper;
 
     /* 받은 결재 목록을 조회하는 메서드 */
@@ -43,16 +43,16 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
         }
 
         // 멤버 존재 여부에 따른 에러 처리
-        if(!approveMapper.existsByEmpId(empId)) {
+        if(!receivedApproveMapper.existsByEmpId(empId)) {
             throw new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND);
         }
 
         // 받은 결재 문서 가져오기
         List<ApproveDTO> approveList
-                = approveMapper.findReceivedApproval(approveListRequest, empId ,pageRequest);
+                = receivedApproveMapper.findReceivedApproval(approveListRequest, empId ,pageRequest);
 
         // 받은 결재 문서 개수 세기
-        long total = approveMapper.countReceivedApproval(approveListRequest, empId);
+        long total = receivedApproveMapper.countReceivedApproval(approveListRequest, empId);
 
         // 페이징 처리를 위한 부분
         int page = pageRequest.getPage();

--- a/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.dao.momentum.approve.query.mapper.ApproveMapper">
+<mapper namespace="com.dao.momentum.approve.query.mapper.ReceivedApproveMapper">
 
     <select id="findReceivedApproval" resultType="com.dao.momentum.approve.query.dto.ApproveDTO">
         SELECT

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveQueryControllerTest.java
@@ -2,7 +2,7 @@ package com.dao.momentum.approve.query.controller;
 
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
-import com.dao.momentum.approve.query.service.AdminApproveService;
+import com.dao.momentum.approve.query.service.AdminApproveQueryService;
 import com.dao.momentum.common.dto.Pagination;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AdminApproveController.class)
-class AdminApproveControllerTest {
+@WebMvcTest(AdminApproveQueryController.class)
+class AdminApproveQueryControllerTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -32,7 +32,7 @@ class AdminApproveControllerTest {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    AdminApproveService adminApproveService;
+    AdminApproveQueryService adminApproveQueryService;
 
     private List<ApproveDTO> getDummyApproves() {
         ApproveDTO dummy1 = ApproveDTO.builder()
@@ -81,7 +81,7 @@ class AdminApproveControllerTest {
                         .build())
                 .build();
 
-        Mockito.when(adminApproveService.getApproveList(Mockito.any(), Mockito.any()))
+        Mockito.when(adminApproveQueryService.getApproveList(Mockito.any(), Mockito.any()))
                 .thenReturn(approveResponse);
 
         System.out.println(approveResponse);

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImplTest.java
@@ -20,13 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-class AdminApproveServiceImplTest {
+class AdminApproveQueryServiceImplTest {
 
     @Mock
     private AdminApproveMapper adminApproveMapper;
 
     @InjectMocks
-    private AdminApproveServiceImpl adminApproveService;
+    private AdminApproveQueryServiceImpl adminApproveService;
 
     @BeforeEach
     void setUp() {

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
@@ -8,7 +8,7 @@ import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
-import com.dao.momentum.approve.query.mapper.ApproveMapper;
+import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.organization.employee.exception.EmployeeException;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ApproveQueryServiceImplTest {
 
     @Mock
-    private ApproveMapper approveMapper;
+    private ReceivedApproveMapper receivedApproveMapper;
 
     @Mock
     private DraftApproveMapper draftApproveMapper;
@@ -50,9 +50,9 @@ class ApproveQueryServiceImplTest {
 
         List<ApproveDTO> dummyList = getDummyApproves();
 
-        when(approveMapper.existsByEmpId(empId)).thenReturn(true);
-        when(approveMapper.findReceivedApproval(request, empId, pageRequest)).thenReturn(dummyList);
-        when(approveMapper.countReceivedApproval(request, empId)).thenReturn((long) dummyList.size());
+        when(receivedApproveMapper.existsByEmpId(empId)).thenReturn(true);
+        when(receivedApproveMapper.findReceivedApproval(request, empId, pageRequest)).thenReturn(dummyList);
+        when(receivedApproveMapper.countReceivedApproval(request, empId)).thenReturn((long) dummyList.size());
 
         ApproveResponse response = approveService.getReceivedApprove(request, empId, pageRequest);
 
@@ -86,7 +86,7 @@ class ApproveQueryServiceImplTest {
         PageRequest pageRequest = new PageRequest(1, 10);
         Long empId = 999L;
 
-        when(approveMapper.existsByEmpId(empId)).thenReturn(false);
+        when(receivedApproveMapper.existsByEmpId(empId)).thenReturn(false);
 
         assertThrows(EmployeeException.class,
                 () -> approveService.getReceivedApprove(request, empId, pageRequest));


### PR DESCRIPTION
closes #3

---

📌 개요
Command와 Query를 구분하기 위해 클래스명 변경

🔨 주요 변경 사항
- `AdminApproveController, AdminApproceService` 중간에 Query 단어 추가
- `ApproveMapper` -> `ReceviedApproveMapper`로 변경

✅ 리뷰 요청 사항

⭐ 관련 이슈
#3
