### PR TITLE
feat : 결재 문서 상세 조회 기능

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveType.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveType.java
@@ -1,5 +1,18 @@
 package com.dao.momentum.approve.command.domain.aggregate;
 
+import com.dao.momentum.approve.exception.NotExistTabException;
+import com.dao.momentum.common.exception.ErrorCode;
+
+import java.util.Arrays;
+
 public enum ApproveType {
-    WORKCORRECTION, VACATION, BUSINESSTRIP, REMOTEWORK, OVERTIME, RECEIPT, PROPOSAL, CANCEL
+    WORKCORRECTION, VACATION, BUSINESSTRIP, REMOTEWORK, OVERTIME, RECEIPT, PROPOSAL, CANCEL;
+
+    // 탭이 있는지 검증
+    public static ApproveType from(String name) {
+        return Arrays.stream(values())
+                .filter(v -> v.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new NotExistTabException(ErrorCode.NOT_EXIST_TAB));
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveType.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveType.java
@@ -1,18 +1,5 @@
 package com.dao.momentum.approve.command.domain.aggregate;
 
-import com.dao.momentum.approve.exception.NotExistTabException;
-import com.dao.momentum.common.exception.ErrorCode;
-
-import java.util.Arrays;
-
 public enum ApproveType {
     WORKCORRECTION, VACATION, BUSINESSTRIP, REMOTEWORK, OVERTIME, RECEIPT, PROPOSAL, CANCEL;
-
-    // 탭이 있는지 검증
-    public static ApproveType from(String name) {
-        return Arrays.stream(values())
-                .filter(v -> v.name().equalsIgnoreCase(name))
-                .findFirst()
-                .orElseThrow(() -> new NotExistTabException(ErrorCode.NOT_EXIST_TAB));
-    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/NotFoundApproveException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/NotFoundApproveException.java
@@ -1,0 +1,15 @@
+package com.dao.momentum.approve.exception;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundApproveException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public NotFoundApproveException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}
+

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
@@ -3,6 +3,7 @@ package com.dao.momentum.approve.query.controller;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveDetailResponse;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
 import com.dao.momentum.approve.query.service.ApproveQueryService;
@@ -15,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -60,5 +62,18 @@ public class ApproveQueryController {
         return ResponseEntity.ok(ApiResponse.success(draftApproveResponse));
     }
 
+    /* 문서 상제 조회 기능 */
+    @GetMapping("/documents/{documentId}")
+    @Operation(summary = "결재 문서 상세 조회", description = "결재 문서를 상세 조회합니다.")
+    public ResponseEntity<ApiResponse<ApproveDetailResponse>> getDraftApprovals(
+            @PathVariable Long documentId
+    ) {
+
+        ApproveDetailResponse approveDetailResponse
+                = approveQueryService.getApproveDetail(documentId);
+
+
+        return ResponseEntity.ok(ApiResponse.success(approveDetailResponse));
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveDTO.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.dto;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,7 +17,7 @@ public class ApproveDTO {
     private String statusType;
     private Long empId;
     private String approveTitle;
-    private String approveType;
+    private ApproveType approveType;
     private LocalDateTime createAt;
     private LocalDateTime completeAt;
     private String employeeName;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
@@ -1,0 +1,17 @@
+package com.dao.momentum.approve.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveFileDTO {
+
+    private String url;
+    private String type;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineDTO.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.approve.query.dto;
+
+import com.dao.momentum.approve.command.domain.aggregate.IsRequiredAll;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveLineDTO {
+
+    private Long approveLineId;
+    private String statusType;
+    private Long approveId;
+    private Integer approveLineOrder;
+    private IsRequiredAll isRequiredAll;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineGroupDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineGroupDTO.java
@@ -1,0 +1,17 @@
+package com.dao.momentum.approve.query.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveLineGroupDTO {
+
+    private ApproveLineDTO approveLineDTO;
+    private List<ApproveLineListDTO> approveLineListDTOs;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineListDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineListDTO.java
@@ -1,0 +1,24 @@
+package com.dao.momentum.approve.query.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveLineListDTO {
+
+    private Long approveLineId;
+    private String statusType;
+    private String employeeDisplayName;
+    private String departmentName;
+    private String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
@@ -1,0 +1,17 @@
+package com.dao.momentum.approve.query.dto;
+
+import com.dao.momentum.approve.command.domain.aggregate.IsConfirmed;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveRefDTO {
+
+    private String employeeDisplayName;
+    private String departmentName;
+    private String isConfirmed;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveCancelDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveCancelDTO.java
@@ -1,0 +1,16 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveCancelDTO {
+
+    private String cancelReason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveProposalDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveProposalDTO.java
@@ -1,0 +1,13 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveProposalDTO {
+
+    private String content;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveReceiptDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveReceiptDTO.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApproveReceiptDTO {
+
+    private String receiptType;
+    private String storeName;
+    private Integer amount;
+    private LocalDateTime usedAt;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/BusinessTripDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/BusinessTripDTO.java
@@ -1,0 +1,21 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BusinessTripDTO {
+
+    private String type;
+    private String place;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String reason;
+    private int cost;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/OvertimeDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/OvertimeDTO.java
@@ -1,0 +1,18 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OvertimeDTO {
+
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private int breakTime;
+    private String reason;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/RemoteWorkDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/RemoteWorkDTO.java
@@ -1,0 +1,18 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RemoteWorkDTO {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/VacationDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/VacationDTO.java
@@ -1,0 +1,18 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VacationDTO {
+
+    private String vacationType;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String reason;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/WorkCorrectionDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/WorkCorrectionDTO.java
@@ -1,0 +1,20 @@
+package com.dao.momentum.approve.query.dto.approveTypeDTO;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkCorrectionDTO {
+
+    private LocalDateTime beforeStartAt;
+    private LocalDateTime beforeEndAt;
+    private LocalDateTime afterStartAt;
+    private LocalDateTime afterEndAt;
+    private String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.dto.request;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -13,7 +14,7 @@ public class ApproveListRequest {
     @NotNull(message = "결재 종류는 반드시 선택해야 합니다.")
     private final String tab;
 
-    private final String approveType;
+    private final ApproveType approveType;
     private final String receiptType;
     private final Integer status;
     private final String title;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveDetailResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveDetailResponse.java
@@ -1,0 +1,20 @@
+package com.dao.momentum.approve.query.dto.response;
+
+import com.dao.momentum.approve.query.dto.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ApproveDetailResponse {
+
+    private ApproveDTO approveDTO;
+    private ApproveDTO parentApproveDTO;
+    private List<ApproveFileDTO> approveFileDTO;
+    private List<ApproveLineGroupDTO> approveLineGroupDTO;
+    private List<ApproveRefDTO> approveRefDTO;
+    private Object formDetail; // 폼의 종류에 따라서 상세 정보가 달라짐
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveDetailMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveDetailMapper.java
@@ -1,0 +1,43 @@
+package com.dao.momentum.approve.query.mapper;
+
+import com.dao.momentum.approve.query.dto.*;
+import com.dao.momentum.approve.query.dto.approveTypeDTO.*;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface ApproveDetailMapper {
+
+    /* 모든 폼에서 공통적으로 조회되는 내용 */
+    Optional<ApproveDTO> getApproveDTO(Long approveId);
+
+    List<ApproveFileDTO> getApproveFiles(Long approveId);
+
+    List<ApproveLineDTO> getApproveLines(Long approveId);
+
+    List<ApproveLineListDTO> getApproveLineList(Long approveLineId);
+
+    List<ApproveRefDTO> getApproveRefs( Long approveId);
+
+    /* 폼별로 상세 조회 */
+    Optional<ApproveProposalDTO> getProposalDetail(Long approveId);
+
+    Optional<ApproveReceiptDTO> getReceiptDetail(Long approveId);
+
+    Optional<ApproveCancelDTO> getCancelDetail(Long approveId);
+
+    Optional<BusinessTripDTO> getBusinessTripDetail(Long approveId);
+
+    Optional<OvertimeDTO> getOvertimeDetail(Long approveId);
+
+    Optional<RemoteWorkDTO> getRemoteWorkDetail(Long approveId);
+
+    Optional<VacationDTO> getVacationDetail(Long approveId);
+
+    Optional<WorkCorrectionDTO> getWorkCorrectionDetail(Long approveId);
+
+}
+
+                            

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
@@ -3,6 +3,7 @@ package com.dao.momentum.approve.query.service;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveDetailResponse;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
 
@@ -21,5 +22,8 @@ public interface ApproveQueryService {
             Long empId,
             PageRequest pageRequest
     );
+
+    /* 결재 상세 조회 메서드 */
+    ApproveDetailResponse getApproveDetail(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
@@ -1,13 +1,16 @@
 package com.dao.momentum.approve.query.service;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.exception.NotExistTabException;
-import com.dao.momentum.approve.query.dto.ApproveDTO;
-import com.dao.momentum.approve.query.dto.DraftApproveDTO;
+import com.dao.momentum.approve.exception.NotFoundApproveException;
+import com.dao.momentum.approve.query.dto.*;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
+import com.dao.momentum.approve.query.dto.response.ApproveDetailResponse;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
+import com.dao.momentum.approve.query.mapper.ApproveDetailMapper;
 import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.common.dto.Pagination;
@@ -15,6 +18,7 @@ import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.organization.employee.exception.EmployeeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.type.TrueFalseConverter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +31,7 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
 
     private final ReceivedApproveMapper receivedApproveMapper;
     private final DraftApproveMapper draftApproveMapper;
+    private final ApproveDetailMapper approveDetailMapper;
 
     /* 받은 결재 목록을 조회하는 메서드 */
     @Transactional(readOnly = true)
@@ -77,7 +82,6 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
     ) {
 
         // 존재하지 않는 결재 탭을 입력하는 경우 에러 처리
-
         List<String> validTabs = List.of("ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
 
         if (!validTabs.contains(draftApproveListRequest.getTab())) {
@@ -110,4 +114,113 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
                 .build();
     }
 
+    /* 결재 상세 목록 조회 하기 */
+    @Transactional(readOnly = true)
+    @Override
+    public ApproveDetailResponse getApproveDetail(Long approveId) {
+        ApproveDTO approveDTO = approveDetailMapper.getApproveDTO(approveId)
+                .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_APPROVE));
+
+        // 취소 결재인 경우
+        if (approveDTO.getApproveType() == ApproveType.CANCEL) {
+            return getCancelApproveDetail(approveDTO);
+        }
+
+        // 일반 결재인 경우 (취소 제외)
+        return getNormalApproveDetail(approveDTO);
+    }
+
+    /* 취소 결재인 경우 */
+    private ApproveDetailResponse getCancelApproveDetail(ApproveDTO cancelDTO) {
+        // 취소 결재 ID
+        Long cancelApproveId = cancelDTO.getApproveId();
+        // 해당 결재의 부모 ID
+        Long parentId = cancelDTO.getParentApproveId();
+
+        // 1. 부모 결재 DTO 조회 하기
+        ApproveDTO parentDTO = approveDetailMapper.getApproveDTO(parentId)
+                .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_APPROVE));
+
+        // 2. 결재 첨부 파일
+        List<ApproveFileDTO> approveFileDTO = approveDetailMapper.getApproveFiles(parentId);
+
+        // 3. 결재선, 결재선 목록
+        List<ApproveLineDTO> lineList = approveDetailMapper.getApproveLines(cancelApproveId);
+        List<ApproveRefDTO> refList = approveDetailMapper.getApproveRefs(cancelApproveId);
+
+        // 4. 폼 정보 가져오기
+        Object formDetail = resolveFormDetail(ApproveType.CANCEL,cancelApproveId);
+
+        return buildApproveDetailResponse(cancelDTO, parentDTO, approveFileDTO, lineList, refList, formDetail);
+    }
+
+    /* 일반 결재인 경우 */
+    private ApproveDetailResponse getNormalApproveDetail(ApproveDTO approveDTO) {
+        // 결재 아이디
+        Long approveId = approveDTO.getApproveId();
+        // 결재 타입
+        ApproveType approveType = approveDTO.getApproveType();
+
+        // 1. 결재 첨부 파일
+        List<ApproveFileDTO> approveFileDTO = approveDetailMapper.getApproveFiles(approveId);
+
+        // 2. 결재선, 결재선 목록
+        List<ApproveLineDTO> lineList = approveDetailMapper.getApproveLines(approveId);
+        List<ApproveRefDTO> refList = approveDetailMapper.getApproveRefs(approveId);
+
+        // 3. 폼 정보 가져오기
+        Object formDetail = resolveFormDetail(approveType, approveId);
+
+        return buildApproveDetailResponse(approveDTO, null, approveFileDTO, lineList, refList, formDetail);
+    }
+
+    /* 공통된 응답인 경우*/
+    private ApproveDetailResponse buildApproveDetailResponse(
+            ApproveDTO approveDTO,
+            ApproveDTO parentApproveDTO,
+            List<ApproveFileDTO> approveFileDTO,
+            List<ApproveLineDTO> lineList,
+            List<ApproveRefDTO> refList,
+            Object formDetail
+    ) {
+        List<ApproveLineGroupDTO> approveLineGroupDTOs = lineList.stream()
+                .map(line -> ApproveLineGroupDTO.builder()
+                        .approveLineDTO(line)
+                        .approveLineListDTOs(
+                                approveDetailMapper.getApproveLineList(line.getApproveLineId())
+                        )
+                        .build())
+                .toList();
+
+        return ApproveDetailResponse.builder()
+                .approveDTO(approveDTO)
+                .parentApproveDTO(parentApproveDTO)
+                .approveFileDTO(approveFileDTO)
+                .approveLineGroupDTO(approveLineGroupDTOs)
+                .approveRefDTO(refList)
+                .formDetail(formDetail)
+                .build();
+    }
+
+    /* 폼 데이터 결정하기 */
+    private Object resolveFormDetail(ApproveType approveType, Long approveId) {
+        return switch (approveType) {
+            case PROPOSAL -> approveDetailMapper.getProposalDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_PROPOSAL));
+            case RECEIPT -> approveDetailMapper.getReceiptDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_RECEIPT));
+            case BUSINESSTRIP -> approveDetailMapper.getBusinessTripDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_BUSINESS_TRIP));
+            case OVERTIME -> approveDetailMapper.getOvertimeDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_OVERTIME));
+            case REMOTEWORK -> approveDetailMapper.getRemoteWorkDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_OVERTIME));
+            case VACATION -> approveDetailMapper.getVacationDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_VACATION));
+            case WORKCORRECTION -> approveDetailMapper.getWorkCorrectionDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_WORK_CORRECTION));
+            case CANCEL -> approveDetailMapper.getCancelDetail(approveId)
+                    .orElseThrow(() -> new NotFoundApproveException(ErrorCode.NOT_EXIST_CANCEL));
+        };
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -32,7 +32,16 @@ public enum ErrorCode {
 
     // 결재 오류 (30001 ~ 39999)
     NOT_EXIST_TAB("30001", "존재하지 않는 결재 탭입니다.", HttpStatus.BAD_REQUEST),
-    
+    NOT_EXIST_APPROVE("30002", "존재하지 않는 결재 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_PROPOSAL("30003", "존재하지 않는 품의 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_RECEIPT("30004", "존재하지 않는 영수증 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_BUSINESS_TRIP("30005", "존재하지 않는 출장 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_OVERTIME("30006", "존재하지 않는 초과 근무 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_REMOTE_WORK("30007", "존재하지 않는 재택 근무 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_VACATION("30008", "존재하지 않는 휴가 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_WORK_CORRECTION("30009", "존재하지 않는 출퇴근 정정 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_CANCEL("30010", "존재하지 않는 취소 결재 상세 내역입니다.", HttpStatus.BAD_REQUEST),
+
     //공지사항 오류(60001 - 69999)
     ANNOUNCEMENT_NOT_FOUND("60001", "해당 공지사항 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ANNOUNCEMENT_NOT_AUTHOR("60002", "해당 공지사항 게시글의 작성자가 아닙니다.", HttpStatus.FORBIDDEN),

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.approve.query.mapper.ApproveDetailMapper">
+
+    <!-- 결재 내역 상세 조회 -->
+    <select id="getApproveDTO" resultType="com.dao.momentum.approve.query.dto.ApproveDTO">
+        SELECT
+            a.approve_id,
+            a.parent_approve_id,
+            s.status_type,
+            a.emp_id,
+            a.approve_title,
+            a.approve_type,
+            a.create_at,
+            a.complete_at,
+            e.name AS employee_name,
+            d.name AS department_name
+        FROM approve a
+        JOIN employee e ON a.emp_id = e.emp_id
+        JOIN department d ON e.dept_id = d.dept_id
+        JOIN status s ON a.status_id = s.status_id
+        WHERE a.approve_id = #{approveId}
+    </select>
+
+    <!-- 결재 내역 파일 조회 -->
+    <select id="getApproveFiles" resultType="com.dao.momentum.approve.query.dto.ApproveFileDTO">
+        SELECT
+            url, type
+        FROM file
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <!-- 결재선 조회 -->
+    <select id="getApproveLines" resultType="com.dao.momentum.approve.query.dto.ApproveLineDTO">
+        SELECT
+            al.approve_line_id,
+            s.status_type,
+            al.approve_id,
+            al.approve_line_order,
+            al.is_required_all
+        FROM approve_line al
+        JOIN status s ON al.status_id = s.status_id
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <!-- 결재선 목록 조회 -->
+    <select id="getApproveLineList" resultType="com.dao.momentum.approve.query.dto.ApproveLineListDTO">
+        SELECT
+            al.approve_line_id,
+            s.status_type,
+            CONCAT(e.name, ' ', p.name) AS employee_display_name,
+            d.name AS department_name,
+            al.reason
+        FROM approve_line_list al
+        JOIN status s ON al.status_id = s.status_id
+        JOIN employee e ON al.emp_id = e.emp_id
+        JOIN department d ON e.dept_id = d.dept_id
+        JOIN position p ON e.position_id = p.position_id
+        WHERE approve_line_id = #{approveLineId}
+    </select>
+
+    <!-- 결재 참조자 조회 -->
+    <select id="getApproveRefs" resultType="com.dao.momentum.approve.query.dto.ApproveRefDTO">
+        SELECT
+            CONCAT(e.name, ' ', p.name) AS employee_display_name,
+            d.name AS department_name,
+            ar.is_confirmed
+        FROM approve_ref ar
+        JOIN employee e ON ar.emp_id = e.emp_id
+        JOIN department d ON e.dept_id = d.dept_id
+        JOIN position p ON e.position_id = p.position_id
+        WHERE approve_id = #{approveId};
+    </select>
+
+    <!-- 결재 종류별 상세 조회 -->
+    <select id="getProposalDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.ApproveProposalDTO">
+        SELECT
+            content
+        FROM approve_proposal
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getReceiptDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.ApproveReceiptDTO">
+        SELECT
+            receipt_type,
+            store_name,
+            amount,
+            used_at
+        FROM approve_receipt
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getCancelDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.ApproveCancelDTO">
+        SELECT
+            cancel_reason
+        FROM approve_cancel
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getBusinessTripDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.BusinessTripDTO">
+        SELECT
+            type,
+            place,
+            start_date,
+            end_date,
+            reason,
+            cost
+        FROM business_trip
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getOvertimeDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.OvertimeDTO">
+        SELECT
+            start_at,
+            end_at,
+            break_time,
+            reason
+        FROM overtime
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getRemoteWorkDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.RemoteWorkDTO">
+        SELECT
+            start_date,
+            end_date,
+            reason
+        FROM remote_work
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getVacationDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.VacationDTO">
+        SELECT
+            vt.vacation_type,
+            v.start_date,
+            v.end_date,
+            v.reason
+        FROM vacation v
+        JOIN vacation_type vt ON v.vacation_id = vt.vacation_type_id
+        WHERE approve_id = #{approveId}
+    </select>
+
+    <select id="getWorkCorrectionDetail" resultType="com.dao.momentum.approve.query.dto.approveTypeDTO.WorkCorrectionDTO">
+        SELECT
+            before_start_at,
+            before_end_at,
+            after_start_at,
+            after_end_at,
+            reason
+        FROM work_correction
+        WHERE approve_id = #{approveId}
+    </select>
+
+</mapper>

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/AdminApproveQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.controller;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.service.AdminApproveQueryService;
@@ -41,7 +42,7 @@ class AdminApproveQueryControllerTest {
                 .statusType("ACCEPTED")
                 .empId(1L)
                 .approveTitle("점심 식사 영수증")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .completeAt(null)
                 .employeeName("장도윤")
@@ -54,7 +55,7 @@ class AdminApproveQueryControllerTest {
                 .statusType("ACCEPTED")
                 .empId(2L)
                 .approveTitle("출장 택시비")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.controller;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.approve.query.dto.DraftApproveDTO;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
@@ -110,7 +111,7 @@ class ApproveQueryControllerTest {
                 .statusType("ACCEPTED")
                 .empId(1L)
                 .approveTitle("점심 식사 영수증")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .completeAt(null)
                 .employeeName("장도윤")
@@ -123,7 +124,7 @@ class ApproveQueryControllerTest {
                 .statusType("ACCEPTED")
                 .empId(2L)
                 .approveTitle("출장 택시비")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
@@ -154,7 +155,6 @@ class ApproveQueryControllerTest {
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .build();
-
 
         return List.of(dummy1, dummy2);
     }

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/AdminApproveQueryServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.service;
 
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.exception.NotExistTabException;
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
@@ -40,7 +41,7 @@ class AdminApproveQueryServiceImplTest {
                 .statusType("ACCEPTED")
                 .empId(1L)
                 .approveTitle("점심 식사 영수증")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 1, 0, 0))
                 .completeAt(null)
                 .employeeName("장도윤")
@@ -53,7 +54,7 @@ class AdminApproveQueryServiceImplTest {
                 .statusType("ACCEPTED")
                 .empId(2L)
                 .approveTitle("출장 택시비")
-                .approveType("RECEIPT")
+                .approveType(ApproveType.RECEIPT)
                 .createAt(LocalDateTime.of(2025, 6, 9, 0, 0))
                 .completeAt(LocalDateTime.of(2025, 6, 13, 0, 0))
                 .employeeName("김하윤")
@@ -83,7 +84,7 @@ class AdminApproveQueryServiceImplTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getApproveDTO().get(0).getApproveTitle()).isEqualTo("점심 식사 영수증");
-        assertThat(result.getApproveDTO().get(1).getApproveType()).isEqualTo("RECEIPT");
+        assertThat(result.getApproveDTO().get(1).getApproveType()).isEqualTo(ApproveType.RECEIPT);
 
         verify(adminApproveMapper, times(1)).findAllApproval(any(), any());
 


### PR DESCRIPTION
closes #8 

---

📌 개요
결재 문서 상세 조회 기능 구현

🔨 주요 변경 사항
- ApproveQueryController
   - /approval/documents/{documents}로 endpoint 설정
- ApproveQueryService, ApproveQueryServiceImpl
   - 결재 문서 상세 조회 메서드 생성 `getApproveDetail`
   - 결재 문서 상세 조회 시 일반 결재와 취소 결재를 나눠서 return하기 때문에 각각 메서드 생성, 결재 상세 내역을 빌드 해주는 메서드 생성 `getCancelApproveDetail`, `getNormalApproveDetail`, `buildApproveDetailResponse`
   - 결재 문서의 종류에 따라서 다른 폼 내용을 전달해주기 위해 `resolveFormDetail` 메서드 생성
   - 요청 시 응답과 에러 처리 완료
   - 서비스 테스트
- ApproveDetailMapper
   - 결재 내역 조회 메서드
   - 결재 첨부 파일 조회 메서드
   - 결재선과 결재선에 있는 사원 목록을 조회하는 메서드
   - 참조자를 조회하는 메서드
   - 결재 문서 종류 별로 상세 조회하는 메서드 생성
- 요청, 응답 객체
   - 각각의 종류 별로 DTO를 생성함 (결재, 결재선, 결재선 목록, 결재 문서)
   - `ApproveDetailResponse` 생성
   
✅ 리뷰 요청 사항
로직 점검 

⭐ 관련 이슈
#8
