### PR TITLE
fix: 출근 등록 기능 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkTimeService.java
@@ -60,6 +60,7 @@ public class WorkTimeService {
     }
 
     LocalDateTime computeStartAt(LocalDateTime startPushedAt, boolean hasAMHalfDayOff) {
+        LocalDateTime truncatedStartPushedAt = startPushedAt.withSecond(0).withNano(0);
         LocalDate startPushedDate = startPushedAt.toLocalDate();
         LocalTime startTime = getStartTime();
         LocalDateTime startAtByPolicy = startPushedDate.atTime(startTime);
@@ -67,12 +68,13 @@ public class WorkTimeService {
         LocalDateTime startAtByPolicyForAMDayoff = startPushedDate.atTime(midTime);
 
         if (hasAMHalfDayOff) {
-            return getLaterOne(startPushedAt, startAtByPolicyForAMDayoff);
+            return getLaterOne(truncatedStartPushedAt, startAtByPolicyForAMDayoff);
         }
-        return getLaterOne(startPushedAt, startAtByPolicy);
+        return getLaterOne(truncatedStartPushedAt, startAtByPolicy);
     }
 
     LocalDateTime computeEndAt(LocalDateTime endPushedAt, boolean hasPMHalfDayOff) {
+        LocalDateTime truncatedEndPushedAt = endPushedAt.withSecond(0).withNano(0);
         LocalDate endPushedDate = endPushedAt.toLocalDate();
         LocalTime endTime = getEndTime();
         LocalDateTime endAtByPolicy = endPushedDate.atTime(endTime);
@@ -80,8 +82,8 @@ public class WorkTimeService {
         LocalDateTime endAtByPolicyForPMDayoff = endPushedDate.atTime(midTime);
 
         if (hasPMHalfDayOff) {
-            return getEarlierOne(endPushedAt, endAtByPolicyForPMDayoff);
+            return getEarlierOne(truncatedEndPushedAt, endAtByPolicyForPMDayoff);
         }
-        return getEarlierOne(endPushedAt, endAtByPolicy);
+        return getEarlierOne(truncatedEndPushedAt, endAtByPolicy);
     }
 }


### PR DESCRIPTION
📌 개요
- 출근 등록 기능 수정

🔨 주요 변경 사항
- 현재: 9시 10분 13초에 출근 등록을 시도하면 `startAt`에 9시 10분 13초가 찍힘
- 변경: 9시 10분 13초에 출근 등록을 시도하면 `startAt`에 9시 10분 00초가 찍힘

출퇴근 시각은 초 단위를 고려하지 않고 분 단위로 관리하는 게 일반적

✅ 리뷰 요청 사항

⭐ 관련 이슈
#13 
