### PR TITLE
feat: 알림 발송 템플릿 구현

### DIFF
--- a/momentum-dao-be/build.gradle
+++ b/momentum-dao-be/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
     // CloudFront Signed URL 생성 시 경로 내 한글/공백 등의 인코딩 문제를 방지하기 위해 URIBuilder 사용
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+
+    // Kafka 클라이언트 라이브러리 의존성 추가
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/momentum-dao-be/docker-compose.yml
+++ b/momentum-dao-be/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 3000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8085:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/KafkaConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/KafkaConfig.java
@@ -1,0 +1,47 @@
+package com.dao.momentum.common.config;
+
+import com.dao.momentum.common.kafka.dto.NotificationMessage;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    /* ProducerFactory 설정
+     * - Kafka에 메시지를 보내는(produce) 역할을 수행
+     * - 서버 주소, 키/값 직렬화 방식 등을 지정
+     */
+    @Bean
+    public ProducerFactory<String, NotificationMessage> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        // 카프카 클러스터의 호스트:포트 (Docker Compose나 외부 서버 등)
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+
+        // 메시지 키를 String 으로 직렬화
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        // 메시지 값을 JSON 으로 직렬화 (NotificationMessage 객체 → JSON 문자열)
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    /* KafkaTemplate 빈 등록
+     * - 메시지를 보내기 위한 편리한 API 제공
+     * - producerFactory를 통해 생성된 프로듀서를 내부에서 사용
+     */
+    @Bean
+    public KafkaTemplate<String, NotificationMessage> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/kafka/dto/NotificationMessage.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/kafka/dto/NotificationMessage.java
@@ -1,0 +1,15 @@
+package com.dao.momentum.common.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationMessage {
+    private String title;
+    private String content;
+    private String type;
+    private String url;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/kafka/producer/NotificationKafkaProducer.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/kafka/producer/NotificationKafkaProducer.java
@@ -1,0 +1,27 @@
+package com.dao.momentum.common.kafka.producer;
+
+import com.dao.momentum.common.kafka.dto.NotificationMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationKafkaProducer {
+
+    private final KafkaTemplate<String, NotificationMessage> kafkaTemplate;
+
+    @Value("${custom.kafka.notification-topic}")
+    private String topic;
+
+    public NotificationKafkaProducer(KafkaTemplate<String, NotificationMessage> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    /**
+     * userId를 key로 설정하면 Kafka가 같은 유저 메시지를 동일한 파티션에 보냄
+     */
+    public void sendNotification(String userId, NotificationMessage message) {
+        kafkaTemplate.send(topic, userId, message);
+    }
+}
+

--- a/momentum-dao-be/src/main/resources/application.yml
+++ b/momentum-dao-be/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
   data:
     redis:
@@ -56,3 +61,7 @@ cloud:
       key-pair-id: K2HAOQD1EYCOQG
       domain: momentum-dao.site
       private-key-path: ${CLOUDFRONT_PRIVATE_KEY_PATH}
+
+custom:
+  kafka:
+    notification-topic: user.notification


### PR DESCRIPTION
closes #180 

---

📌 개요
Kafka 기반 알림 발송 템플릿 구현

🔨 주요 변경 사항
- Kafka 관련 의존성 추가
- Kafka 빈 설정
- 알림 발송용 NotificationKafkaProducer 공통 유틸 클래스 정의
