### PR TITLE
feat: 파일 관련 클래스 -> 공통 도메인으로 추출

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/mapper/AnnouncementMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/mapper/AnnouncementMapper.java
@@ -4,7 +4,7 @@ import com.dao.momentum.announcement.command.application.dto.request.Announcemen
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementCreateResponse;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementModifyResponse;
 import com.dao.momentum.announcement.command.domain.aggregate.Announcement;
-import com.dao.momentum.announcement.command.domain.aggregate.IsDeleted;
+import com.dao.momentum.file.command.domain.aggregate.IsDeleted;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
@@ -9,13 +9,13 @@ import com.dao.momentum.announcement.command.application.dto.response.Announceme
 import com.dao.momentum.announcement.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.announcement.command.application.mapper.AnnouncementMapper;
 import com.dao.momentum.announcement.command.domain.aggregate.Announcement;
-import com.dao.momentum.announcement.command.domain.aggregate.File;
 import com.dao.momentum.announcement.command.domain.repository.AnnouncementRepository;
-import com.dao.momentum.announcement.command.domain.repository.FileRepository;
 import com.dao.momentum.announcement.exception.FileUploadFailedException;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
 import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.file.command.domain.aggregate.File;
+import com.dao.momentum.file.command.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/Announcement.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/Announcement.java
@@ -2,6 +2,7 @@ package com.dao.momentum.announcement.command.domain.aggregate;
 
 import com.dao.momentum.announcement.exception.AnnouncementAccessDeniedException;
 import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.file.command.domain.aggregate.IsDeleted;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/IsDeleted.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/domain/aggregate/IsDeleted.java
@@ -1,5 +1,0 @@
-package com.dao.momentum.announcement.command.domain.aggregate;
-
-public enum IsDeleted {
-    Y, N
-}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/controller/FileController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/controller/FileController.java
@@ -1,9 +1,9 @@
-package com.dao.momentum.common.file.controller;
+package com.dao.momentum.file.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
-import com.dao.momentum.common.file.dto.request.DownloadUrlRequest;
-import com.dao.momentum.common.file.dto.response.DownloadUrlResponse;
-import com.dao.momentum.common.file.service.FileService;
+import com.dao.momentum.file.command.application.dto.request.DownloadUrlRequest;
+import com.dao.momentum.file.command.application.dto.response.DownloadUrlResponse;
+import com.dao.momentum.file.command.application.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/DownloadUrlRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/DownloadUrlRequest.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.common.file.dto.request;
+package com.dao.momentum.file.command.application.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/response/DownloadUrlResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/response/DownloadUrlResponse.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.common.file.dto.response;
+package com.dao.momentum.file.command.application.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
@@ -1,6 +1,6 @@
-package com.dao.momentum.common.file.service;
+package com.dao.momentum.file.command.application.service;
 
-import com.dao.momentum.common.file.dto.response.DownloadUrlResponse;
+import com.dao.momentum.file.command.application.dto.response.DownloadUrlResponse;
 import com.dao.momentum.common.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/aggregate/File.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/aggregate/File.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.announcement.command.domain.aggregate;
+package com.dao.momentum.file.command.domain.aggregate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/aggregate/IsDeleted.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/aggregate/IsDeleted.java
@@ -1,0 +1,5 @@
+package com.dao.momentum.file.command.domain.aggregate;
+
+public enum IsDeleted {
+    Y, N
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/repository/FileRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/repository/FileRepository.java
@@ -1,6 +1,6 @@
-package com.dao.momentum.announcement.command.domain.repository;
+package com.dao.momentum.file.command.domain.repository;
 
-import com.dao.momentum.announcement.command.domain.aggregate.File;
+import com.dao.momentum.file.command.domain.aggregate.File;
 
 import java.util.List;
 import java.util.Optional;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/infrastructure/repository/JpaFileRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/infrastructure/repository/JpaFileRepository.java
@@ -1,8 +1,9 @@
-package com.dao.momentum.announcement.command.infrastructure.repository;
+package com.dao.momentum.file.command.infrastructure.repository;
 
-import com.dao.momentum.announcement.command.domain.aggregate.File;
-import com.dao.momentum.announcement.command.domain.repository.FileRepository;
+import com.dao.momentum.file.command.domain.aggregate.File;
+import com.dao.momentum.file.command.domain.repository.FileRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 
 public interface JpaFileRepository extends JpaRepository<File, Long>, FileRepository {


### PR DESCRIPTION
closes #182 

---

📌 개요
파일 관련 클래스 -> 공통 도메인으로 추출

🔨 주요 변경 사항
-  기존 announcement 하위에 있던 File 관련 도메인을 별도의 공통 도메인 컨택스트로 분리하여 관리
