### PR TITLE
refactor: S3 Presigned URL 업로드 로직 -> File 공통 도메인 하위로 이동

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandController.java
@@ -2,13 +2,11 @@ package com.dao.momentum.announcement.command.application.controller;
 
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementCreateRequest;
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementModifyRequest;
-import com.dao.momentum.announcement.command.application.dto.request.FilePresignedUrlRequest;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementCreateResponse;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementModifyResponse;
-import com.dao.momentum.announcement.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.announcement.command.application.service.AnnouncementCommandService;
 import com.dao.momentum.announcement.exception.AnnouncementAccessDeniedException;
-import com.dao.momentum.announcement.exception.FileUploadFailedException;
+import com.dao.momentum.file.exception.FileUploadFailedException;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.common.exception.ErrorCode;
@@ -27,14 +25,6 @@ import org.springframework.web.bind.annotation.*;
 public class AnnouncementCommandController {
 
     private final AnnouncementCommandService announcementCommandService;
-
-    @PostMapping("/presigned-url")
-    public ResponseEntity<ApiResponse<FilePresignedUrlResponse>> generatePresignedUrl(@RequestBody FilePresignedUrlRequest request) {
-        FilePresignedUrlResponse response =
-                announcementCommandService.generatePresignedUrl(request);
-
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<AnnouncementCreateResponse>> createAnnouncement(

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/dto/request/AnnouncementCreateRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/dto/request/AnnouncementCreateRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.announcement.command.application.dto.request;
 
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/dto/request/AnnouncementModifyRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/dto/request/AnnouncementModifyRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.announcement.command.application.dto.request;
 
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandService.java
@@ -11,7 +11,7 @@ import com.dao.momentum.announcement.command.domain.repository.AnnouncementRepos
 import com.dao.momentum.file.exception.FileUploadFailedException;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
 import com.dao.momentum.common.exception.ErrorCode;
-import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.common.s3.S3Service;
 import com.dao.momentum.file.command.domain.aggregate.File;
 import com.dao.momentum.file.command.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode {
 
     // 파일 처리 오류(80001 - 89999)
     FILE_UPLOAD_FAIL("80001", "파일 업로드에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_TOO_LARGE("80002", "파일은 10MB 이하만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_EXTENSION("80003", "허용되지 않은 파일 확장자입니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류
     VALIDATION_ERROR("90001", "입력 값 검증 오류입니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/s3/S3Service.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/s3/S3Service.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.common.service;
+package com.dao.momentum.common.s3;
 
 import com.dao.momentum.file.command.application.dto.response.FilePresignedUrlResponse;
 import lombok.RequiredArgsConstructor;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/service/S3Service.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/service/S3Service.java
@@ -1,6 +1,6 @@
 package com.dao.momentum.common.service;
 
-import com.dao.momentum.announcement.command.application.dto.response.FilePresignedUrlResponse;
+import com.dao.momentum.file.command.application.dto.response.FilePresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.utils.URIBuilder;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/controller/FileController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/controller/FileController.java
@@ -1,15 +1,16 @@
 package com.dao.momentum.file.command.application.controller;
 
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.file.command.application.dto.request.FilePresignedUrlRequest;
+import com.dao.momentum.file.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.file.command.application.dto.request.DownloadUrlRequest;
 import com.dao.momentum.file.command.application.dto.response.DownloadUrlResponse;
 import com.dao.momentum.file.command.application.service.FileService;
+import com.dao.momentum.file.exception.FileUploadFailedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -18,10 +19,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class FileController {
     private final FileService fileService;
 
+    @PostMapping("/presigned-url")
+    public ResponseEntity<ApiResponse<FilePresignedUrlResponse>> generatePresignedUrl(@RequestBody FilePresignedUrlRequest request) {
+        FilePresignedUrlResponse response =
+                fileService.generatePresignedUrl(request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @PostMapping("/download-url")
     public ResponseEntity<ApiResponse<DownloadUrlResponse>> getDownloadUrl(@RequestBody DownloadUrlRequest request) {
         DownloadUrlResponse response = fileService.generateDownloadUrl(request.getKey());
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @ExceptionHandler(FileUploadFailedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFileUploadFailedException(FileUploadFailedException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage()));
     }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/AttachmentRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/AttachmentRequest.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.announcement.command.application.dto.request;
+package com.dao.momentum.file.command.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/FilePresignedUrlRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/request/FilePresignedUrlRequest.java
@@ -1,3 +1,3 @@
-package com.dao.momentum.announcement.command.application.dto.request;
+package com.dao.momentum.file.command.application.dto.request;
 
 public record FilePresignedUrlRequest(String fileName, long sizeInBytes, String contentType) {}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/response/FilePresignedUrlResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/dto/response/FilePresignedUrlResponse.java
@@ -1,3 +1,3 @@
-package com.dao.momentum.announcement.command.application.dto.response;
+package com.dao.momentum.file.command.application.dto.response;
 
 public record FilePresignedUrlResponse(String presignedUrl, String s3Key) {}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
@@ -4,7 +4,7 @@ import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.file.command.application.dto.request.FilePresignedUrlRequest;
 import com.dao.momentum.file.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.file.command.application.dto.response.DownloadUrlResponse;
-import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.common.s3.S3Service;
 import com.dao.momentum.file.exception.FileUploadFailedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
@@ -1,16 +1,45 @@
 package com.dao.momentum.file.command.application.service;
 
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.file.command.application.dto.request.FilePresignedUrlRequest;
+import com.dao.momentum.file.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.file.command.application.dto.response.DownloadUrlResponse;
 import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.file.exception.FileUploadFailedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class FileService {
     private final S3Service s3Service;
+
+    public FilePresignedUrlResponse generatePresignedUrl(FilePresignedUrlRequest request) {
+        final long MAX_SIZE = 10 * 1024 * 1024; // 10MB 제한
+        if (request.sizeInBytes() > MAX_SIZE) {
+            throw new FileUploadFailedException(ErrorCode.FILE_TOO_LARGE);
+        }
+
+        String extension = s3Service.extractFileExtension(request.fileName());
+        if (extension == null || !List.of(
+                "jpg", "jpeg", "png",   // 이미지
+                "pdf", "docx", "txt",   // 문서
+                "hwp", "hwpx",          // 한글
+                "xlsx", "xls",          // 엑셀
+                "pptx", "ppt"           // 파워포인트
+        ).contains(extension)) {
+            throw new FileUploadFailedException(ErrorCode.INVALID_FILE_EXTENSION);
+        }
+
+        String sanitizedFilename = s3Service.sanitizeFilename(request.fileName());
+        String key = "announcements/" + UUID.randomUUID() + "/" + sanitizedFilename;
+
+        return s3Service.generatePresignedUploadUrlWithKey(key, request.contentType());
+    }
 
     public DownloadUrlResponse generateDownloadUrl(String key) {
         String signedUrl = s3Service.generateCloudFrontSignedUrl(key, Duration.ofMinutes(5));

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/exception/FileUploadFailedException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/exception/FileUploadFailedException.java
@@ -1,4 +1,4 @@
-package com.dao.momentum.announcement.exception;
+package com.dao.momentum.file.exception;
 
 import com.dao.momentum.common.exception.ErrorCode;
 import lombok.Getter;

--- a/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/controller/AnnouncementCommandControllerTest.java
@@ -2,11 +2,9 @@ package com.dao.momentum.announcement.command.application.controller;
 
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementCreateRequest;
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementModifyRequest;
-import com.dao.momentum.announcement.command.application.dto.request.AttachmentRequest;
-import com.dao.momentum.announcement.command.application.dto.request.FilePresignedUrlRequest;
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementCreateResponse;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementModifyResponse;
-import com.dao.momentum.announcement.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.announcement.command.application.service.AnnouncementCommandService;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
 import com.dao.momentum.common.exception.ErrorCode;
@@ -43,26 +41,6 @@ class AnnouncementCommandControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Test
-    @DisplayName("Presigned URL 생성 성공")
-    void generatePresignedUrl_success() throws Exception {
-        FilePresignedUrlRequest request = new FilePresignedUrlRequest("test.png",1024 * 1024, "image/png"); // 1MB
-
-        FilePresignedUrlResponse response = new FilePresignedUrlResponse(
-                "https://s3-url.com/announcements/uuid/test.png",
-                "announcements/uuid/test.png"
-        );
-
-        when(announcementCommandService.generatePresignedUrl(any())).thenReturn(response);
-
-        mockMvc.perform(post("/announcement/presigned-url")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.presignedUrl").value(response.presignedUrl()))
-                .andExpect(jsonPath("$.data.s3Key").value(response.s3Key()));
-    }
 
     @Test
     @DisplayName("공지사항 등록 성공 (파일 포함)")

--- a/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandServiceTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandServiceTest.java
@@ -10,7 +10,7 @@ import com.dao.momentum.announcement.command.domain.aggregate.Announcement;
 import com.dao.momentum.announcement.command.domain.repository.AnnouncementRepository;
 import com.dao.momentum.announcement.exception.AnnouncementAccessDeniedException;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
-import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.common.s3.S3Service;
 import com.dao.momentum.file.command.domain.aggregate.File;
 import com.dao.momentum.file.command.domain.repository.FileRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandServiceTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/announcement/command/application/service/AnnouncementCommandServiceTest.java
@@ -2,19 +2,17 @@ package com.dao.momentum.announcement.command.application.service;
 
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementCreateRequest;
 import com.dao.momentum.announcement.command.application.dto.request.AnnouncementModifyRequest;
-import com.dao.momentum.announcement.command.application.dto.request.AttachmentRequest;
-import com.dao.momentum.announcement.command.application.dto.request.FilePresignedUrlRequest;
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementCreateResponse;
 import com.dao.momentum.announcement.command.application.dto.response.AnnouncementModifyResponse;
-import com.dao.momentum.announcement.command.application.dto.response.FilePresignedUrlResponse;
 import com.dao.momentum.announcement.command.application.mapper.AnnouncementMapper;
 import com.dao.momentum.announcement.command.domain.aggregate.Announcement;
-import com.dao.momentum.announcement.command.domain.aggregate.File;
 import com.dao.momentum.announcement.command.domain.repository.AnnouncementRepository;
-import com.dao.momentum.announcement.command.domain.repository.FileRepository;
 import com.dao.momentum.announcement.exception.AnnouncementAccessDeniedException;
 import com.dao.momentum.announcement.exception.NoSuchAnnouncementException;
 import com.dao.momentum.common.service.S3Service;
+import com.dao.momentum.file.command.domain.aggregate.File;
+import com.dao.momentum.file.command.domain.repository.FileRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,50 +45,6 @@ class AnnouncementCommandServiceTest {
 
     @InjectMocks
     private AnnouncementCommandService announcementCommandService;
-
-    @Test
-    @DisplayName("Presigned URL 생성 성공")
-    void generatePresignedUrl_success() {
-        // given
-        FilePresignedUrlRequest request = new FilePresignedUrlRequest("test.png", 1024 * 1024, "image/png");
-
-        when(s3Service.extractFileExtension("test.png")).thenReturn("png");
-        when(s3Service.sanitizeFilename("test.png")).thenReturn("test.png");
-        when(s3Service.generatePresignedUploadUrlWithKey(anyString(), eq("image/png")))
-                .thenReturn(new FilePresignedUrlResponse("https://presigned.url", "announcements/uuid/test.png"));
-
-        // when
-        FilePresignedUrlResponse response = announcementCommandService.generatePresignedUrl(request);
-
-        // then
-        assertNotNull(response);
-        assertTrue(response.presignedUrl().startsWith("https://presigned.url"));
-        assertTrue(response.s3Key().startsWith("announcements/"));
-    }
-
-    @Test
-    @DisplayName("Presigned URL 생성 실패 - 파일 크기 초과")
-    void generatePresignedUrl_fail_fileTooLarge() {
-        FilePresignedUrlRequest request = new FilePresignedUrlRequest("test.png", 11 * 1024 * 1024, "image/png");
-
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> announcementCommandService.generatePresignedUrl(request));
-
-        assertEquals("파일은 10MB 이하만 업로드 가능합니다.", exception.getMessage());
-    }
-
-    @Test
-    @DisplayName("Presigned URL 생성 실패 - 허용되지 않은 확장자")
-    void generatePresignedUrl_fail_invalidExtension() {
-        FilePresignedUrlRequest request = new FilePresignedUrlRequest("malware.exe", 1024 * 1024, "application/octet-stream");
-
-        when(s3Service.extractFileExtension("malware.exe")).thenReturn("exe");
-
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> announcementCommandService.generatePresignedUrl(request));
-
-        assertEquals("허용되지 않은 파일 확장자입니다.", exception.getMessage());
-    }
 
     @Test
     @DisplayName("공지사항 생성 성공")


### PR DESCRIPTION
closes #184 

---

📌 개요
S3 Presigned URL 업로드 로직 -> File 공통 도메인 하위로 이동

🔨 주요 변경 사항
- S3 Presigned URL 업로드 로직 -> File 공통 도메인 하위로 이동
- 파일 업로드 관련 FileUploadException 커스텀 Exception 클래스 및 ErrorCode 정의
- S3 Service 패키지명 수정(common.service -> common.s3)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
