### PR TITLE
refactor : 엔티티에서 default 값 설정 및 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
@@ -47,11 +47,11 @@ public class Approve {
 
     @Builder
     public Approve(
-            Long parentApproveId, Integer statusId, Long empId, String approveTitle,
+            Long parentApproveId, Long empId, String approveTitle,
             ApproveType approveType, LocalDateTime completeAt, LocalDateTime cancelAt
     ) {
         this.parentApproveId = parentApproveId;
-        this.statusId = statusId;
+        this.statusId = 1;
         this.empId = empId;
         this.approveTitle = approveTitle;
         this.approveType = approveType;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLine.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLine.java
@@ -36,9 +36,9 @@ public class ApproveLine {
     private LocalDateTime completeAt;
 
     @Builder
-    public ApproveLine(Integer statusId, Long approveId, Integer approveLineOrder,
+    public ApproveLine(Long approveId, Integer approveLineOrder,
                        IsRequiredAll isRequiredAll, LocalDateTime completeAt) {
-        this.statusId = statusId;
+        this.statusId = 1;
         this.approveId = approveId;
         this.approveLineOrder = approveLineOrder;
         this.isRequiredAll = isRequiredAll;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLineList.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLineList.java
@@ -35,10 +35,10 @@ public class ApproveLineList {
     private String reason;
 
     @Builder
-    public ApproveLineList(Long approveLineId, Integer statusId, Long empId,
+    public ApproveLineList(Long approveLineId, Long empId,
                            LocalDateTime completeAt, String reason) {
         this.approveLineId = approveLineId;
-        this.statusId = statusId;
+        this.statusId = 1;
         this.empId = empId;
         this.completeAt = completeAt;
         this.reason = reason;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveReceipt.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveReceipt.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -29,18 +29,22 @@ public class ApproveReceipt {
     @Column(name = "store_name", nullable = false)
     private String storeName;
 
+    @Column(name = "store_address", nullable = false)
+    private String storeAddress;
+
     @Column(name = "amount", nullable = false)
     private Integer amount;
 
     @Column(name = "used_at", nullable = false)
-    private LocalDateTime usedAt;
+    private LocalDate usedAt;
 
     @Builder
     public ApproveReceipt(Long approveId, ReceiptType receiptType, String storeName,
-                          Integer amount, LocalDateTime usedAt) {
+                          String storeAddress, Integer amount, LocalDate usedAt) {
         this.receiptType = receiptType;
         this.approveId = approveId;
         this.storeName = storeName;
+        this.storeAddress = storeAddress;
         this.amount = amount;
         this.usedAt = usedAt;
     }


### PR DESCRIPTION
closes #000

---

📌 개요
엔티티 수정

🔨 주요 변경 사항
- `approve`, `approve_line`, `approve_line_list` 상태 default를 1로 설정 (대기 상태로 설정)
- `approve_receipt` 가게 주소 추가 및 사용날짜를 `LocalDate`로 변경

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
