### PR TITLE
[feat #94 #95] 면담 기록 내역 조회 및 면담 요청 내역 조회 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
 
     // 근속 지원 오류 (50001 ~ 59999)
     RETENTION_FORECAST_NOT_FOUND("50001", "조회 가능한 근속 전망 정보가 없습니다.", HttpStatus.NOT_FOUND),
+    RETENTION_CONTACT_NOT_FOUND("50002", "조회 가능한 면담 요청 내역 정보가 없습니다.", HttpStatus.NOT_FOUND),
 
 
     //공지사항 오류(60001 - 69999)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/controller/RetentionContactQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/controller/RetentionContactQueryController.java
@@ -1,0 +1,36 @@
+package com.dao.momentum.retention.query.controller;
+
+import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
+import com.dao.momentum.retention.query.service.RetentionContactQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/retention/contact")
+public class RetentionContactQueryController {
+
+    private final RetentionContactQueryService service;
+
+    @GetMapping
+    @Operation(summary = "면담 기록 목록 조회", description = "전체 사원 면담 기록을 필터 조건으로 조회")
+    public ApiResponse<RetentionContactListResultDto> getContactList(
+            @ModelAttribute RetentionContactListRequestDto req) {
+        return ApiResponse.success(service.getContactList(req));
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "나에게 요청된 면담 기록 조회", description = "로그인 사용자가 상급자인 면담 기록만 조회")
+    public ApiResponse<RetentionContactListResultDto> getMyContactRequests(
+            @ModelAttribute RetentionContactListRequestDto req,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.success(service.getMyRequestedContactList(empId, req));
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/controller/RetentionContactQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/controller/RetentionContactQueryController.java
@@ -2,6 +2,7 @@ package com.dao.momentum.retention.query.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
 import com.dao.momentum.retention.query.service.RetentionContactQueryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,5 +33,15 @@ public class RetentionContactQueryController {
     ) {
         Long empId = Long.parseLong(userDetails.getUsername());
         return ApiResponse.success(service.getMyRequestedContactList(empId, req));
+    }
+
+    @GetMapping("/{retentionId}")
+    @Operation(summary = "면담 기록 상세 조회", description = "해당 retentionId에 대한 면담 기록 세부 내역 조회")
+    public ApiResponse<RetentionContactDetailDto> getContactDetail(
+            @PathVariable Long retentionId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.success(service.getContactDetail(retentionId, empId));
     }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionContactListRequestDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionContactListRequestDto.java
@@ -1,0 +1,47 @@
+package com.dao.momentum.retention.query.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Schema(description = "면담 기록 목록 조회 요청 DTO")
+public class RetentionContactListRequestDto {
+
+    @Schema(description = "사번", example = "20240001")
+    private String targetNo;
+
+    @Schema(description = "상급자 ID", example = "34")
+    private Long managerId;
+
+    @Schema(description = "상급자 사번", example = "34")
+    private String managerNo;
+
+    @Schema(description = "부서 ID (필터)", example = "5")
+    private Integer deptId;
+
+    @Schema(description = "직위 ID (필터)", example = "3")
+    private Integer positionId;
+
+    @Schema(description = "조회 시작일", example = "2025-06-01")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @Schema(description = "조회 종료일", example = "2025-06-30")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @Schema(description = "페이지 번호", example = "1", defaultValue = "1")
+    private int page = 1;
+
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
+    private int size = 10;
+
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionForecastRequestDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionForecastRequestDto.java
@@ -13,6 +13,9 @@ public class RetentionForecastRequestDto {
     @Schema(description = "조회할 회차 번호 (미입력 시 최신 회차로 처리)", example = "3")
     private Integer roundNo;
 
+    @Schema(description = "사번", example = "20240001")
+    private String empNo;
+
     @Schema(description = "부서 ID (필터)", example = "5")
     private Integer deptId;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionSupportRaw.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/request/RetentionSupportRaw.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 @Schema(description = "Retention 지원용 원시 데이터 DTO")
 public class RetentionSupportRaw {
 
+    @Schema(description = "사번", example = "20250001")
+    private String empNo;
+
     @Schema(description = "사원 이름", example = "김현우")
     private String empName;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactDetailDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactDetailDto.java
@@ -1,0 +1,56 @@
+package com.dao.momentum.retention.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "면담 기록 세부 조회 응답 DTO")
+public class RetentionContactDetailDto {
+
+    @Schema(description = "면담 기록 ID", example = "1001")
+    private Long retentionId;
+
+    @Schema(description = "대상자 이름", example = "이하준")
+    private String targetName;
+
+    @Schema(description = "대상자 사번", example = "20250020")
+    private String targetNo;
+
+    @Schema(description = "대상자 부서명", example = "프론트엔드팀")
+    private String deptName;
+
+    @Schema(description = "대상자 직급", example = "대리")
+    private String positionName;
+
+    @Schema(description = "면담 진행자 ID", example = "101")
+    private Long managerId;
+
+    @Schema(description = "면담 진행자 이름", example = "정지우")
+    private String managerName;
+
+    @Schema(description = "면담 요청 사유", example = "복지 불만 비율이 높아짐")
+    private String reason;
+
+    @Schema(description = "면담 요청일시", example = "2025-06-20T10:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "상급자 대응 보고 내용", example = "개인 면담 후 만족도 향상 확인")
+    private String response;
+
+    @Schema(description = "대응 보고 일시", example = "2025-06-21T14:30:00")
+    private LocalDateTime responseAt;
+
+    @Schema(description = "인사팀 피드백 내용", example = "복지 개선 요청 검토 중")
+    private String feedback;
+
+    @Schema(description = "피드백 작성 가능 여부 (보고 완료 & 피드백 없음)", example = "true")
+    private boolean feedbackWritable;
+
+    @Schema(description = "요청 삭제 가능 여부 (아직 대응이 없는 경우)", example = "true")
+    private boolean deletable;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactItemDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactItemDto.java
@@ -1,0 +1,34 @@
+package com.dao.momentum.retention.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "면담 기록 항목 DTO")
+public class RetentionContactItemDto {
+
+    @Schema(description = "면담 요청 일시", example = "2025-06-01T09:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "사번", example = "20240001")
+    private String empNo;
+
+    @Schema(description = "대상자 이름", example = "김예은")
+    private String targetName;
+
+    @Schema(description = "부서 이름", example = "인사팀")
+    private String deptName;
+
+    @Schema(description = "직급 이름", example = "과장")
+    private String positionName;
+
+    @Schema(description = "상급자 이름", example = "김하윤")
+    private String managerName;
+
+    @Schema(description = "면담 요청 사유")
+    private String reason;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactListResultDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionContactListResultDto.java
@@ -1,0 +1,20 @@
+package com.dao.momentum.retention.query.dto.response;
+
+import com.dao.momentum.common.dto.Pagination;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "면담 기록 목록 응답 DTO")
+public class RetentionContactListResultDto {
+
+    @Schema(description = "면담 기록 항목 목록")
+    private List<RetentionContactItemDto> items;
+
+    @Schema(description = "페이지네이션 정보")
+    private Pagination pagination;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionForecastItemDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/dto/response/RetentionForecastItemDto.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 @Schema(description = "근속 전망 항목 DTO")
 public class RetentionForecastItemDto {
 
+    @Schema(description = "사번", example = "20240001")
+    private String empNo;
+
     @Schema(description = "사원 이름", example = "김현우")
     private String empName;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionContactMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionContactMapper.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.retention.query.mapper;
 
 import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -10,7 +11,12 @@ import java.util.List;
 @Mapper
 public interface RetentionContactMapper {
 
+    // 면담 요청 내역 조회
     List<RetentionContactItemDto> findContacts(@Param("req") RetentionContactListRequestDto req);
 
     int countContacts(@Param("req") RetentionContactListRequestDto req);
+
+    // 면담 상세 조회
+    RetentionContactDetailDto findContactDetailById(@Param("retentionId") Long retentionId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionContactMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionContactMapper.java
@@ -1,0 +1,16 @@
+package com.dao.momentum.retention.query.mapper;
+
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface RetentionContactMapper {
+
+    List<RetentionContactItemDto> findContacts(@Param("req") RetentionContactListRequestDto req);
+
+    int countContacts(@Param("req") RetentionContactListRequestDto req);
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionStatisticsMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/mapper/RetentionStatisticsMapper.java
@@ -15,7 +15,7 @@ public interface RetentionStatisticsMapper {
     RetentionAverageScoreDto findAverageRetentionScore(@Param("req") RetentionStatisticsRequestDto req);
 
     // 2. 연도별 + 부서별 근속 안정성 분포 집계
-    List<StabilityRatioByDeptRaw> findStabilityDistributionByDept(@Param("year") int year);
+    List<StabilityRatioByDeptRaw> findStabilityDistributionByDept(@Param("year") RetentionStatisticsRequestDto req);
 
     // 전체(또는 부서필터) 기준 근속 안정성 분포 통계
     StabilityRatioByDeptRaw findOverallStabilityDistribution(@Param("req") RetentionStatisticsRequestDto req);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryService.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.retention.query.service;
+
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
+
+public interface RetentionContactQueryService {
+
+    RetentionContactListResultDto getContactList(RetentionContactListRequestDto req);
+
+    RetentionContactListResultDto getMyRequestedContactList(Long empId, RetentionContactListRequestDto req);
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryService.java
@@ -1,11 +1,17 @@
 package com.dao.momentum.retention.query.service;
 
 import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
 
 public interface RetentionContactQueryService {
 
+    // 면담 요청 및 내역 조회
     RetentionContactListResultDto getContactList(RetentionContactListRequestDto req);
 
     RetentionContactListResultDto getMyRequestedContactList(Long empId, RetentionContactListRequestDto req);
+
+    // 면담 상세 조회
+    RetentionContactDetailDto getContactDetail(Long retentionId, Long requesterEmpId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImpl.java
@@ -1,0 +1,54 @@
+package com.dao.momentum.retention.query.service;
+
+import com.dao.momentum.common.dto.Pagination;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.retention.exception.RetentionException;
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
+import com.dao.momentum.retention.query.mapper.RetentionContactMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RetentionContactQueryServiceImpl implements RetentionContactQueryService {
+
+    private final RetentionContactMapper mapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RetentionContactListResultDto getContactList(RetentionContactListRequestDto req) {
+        return buildContactListResponse(req);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RetentionContactListResultDto getMyRequestedContactList(Long empId, RetentionContactListRequestDto req) {
+        req.setManagerId(empId); // 로그인한 상급자 ID 고정
+        return buildContactListResponse(req);
+    }
+
+    private RetentionContactListResultDto buildContactListResponse(RetentionContactListRequestDto req) {
+        long total = mapper.countContacts(req);
+
+        List<RetentionContactItemDto> items = mapper.findContacts(req);
+        if (items == null) {
+            throw new RetentionException(ErrorCode.RETENTION_CONTACT_NOT_FOUND);
+        }
+
+        Pagination pagination = Pagination.builder()
+                .currentPage(req.getPage())
+                .totalItems(total)
+                .totalPage((int) Math.ceil((double) total / req.getSize()))
+                .build();
+
+        return RetentionContactListResultDto.builder()
+                .items(items)
+                .pagination(pagination)
+                .build();
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.dao.momentum.common.dto.Pagination;
 import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.retention.exception.RetentionException;
 import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
 import com.dao.momentum.retention.query.mapper.RetentionContactMapper;
@@ -51,4 +52,36 @@ public class RetentionContactQueryServiceImpl implements RetentionContactQuerySe
                 .pagination(pagination)
                 .build();
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RetentionContactDetailDto getContactDetail(Long retentionId, Long requesterEmpId) {
+        RetentionContactDetailDto detail = mapper.findContactDetailById(retentionId);
+
+        if (detail == null) {
+            throw new RetentionException(ErrorCode.RETENTION_CONTACT_NOT_FOUND);
+        }
+
+        // 플래그 계산
+        boolean deletable = detail.getResponse() == null;
+        boolean feedbackWritable = detail.getResponse() != null && detail.getFeedback() == null;
+
+        return RetentionContactDetailDto.builder()
+                .retentionId(detail.getRetentionId())
+                .targetName(detail.getTargetName())
+                .targetNo(detail.getTargetNo())
+                .deptName(detail.getDeptName())
+                .positionName(detail.getPositionName())
+                .managerId(detail.getManagerId())
+                .managerName(detail.getManagerName())
+                .reason(detail.getReason())
+                .createdAt(detail.getCreatedAt())
+                .response(detail.getResponse())
+                .responseAt(detail.getResponseAt())
+                .feedback(detail.getFeedback())
+                .deletable(deletable)
+                .feedbackWritable(feedbackWritable)
+                .build();
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionStatisticsQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionStatisticsQueryServiceImpl.java
@@ -38,9 +38,11 @@ public class RetentionStatisticsQueryServiceImpl implements RetentionStatisticsQ
     @Override
     @Transactional(readOnly = true)
     public List<StabilityDistributionByDeptDto> getStabilityDistributionByDept(RetentionStatisticsRequestDto req) {
-        int targetYear = (req.getYear() != null) ? req.getYear() : LocalDate.now().getYear();
 
-        List<StabilityRatioByDeptRaw> rawList = mapper.findStabilityDistributionByDept(targetYear);
+        int targetYear = (req.getYear() != null) ? req.getYear() : LocalDate.now().getYear();
+        req.setYear(targetYear); // Mapper에서 사용하므로 DTO에도 세팅
+
+        List<StabilityRatioByDeptRaw> rawList = mapper.findStabilityDistributionByDept(req);
 
         if (rawList == null) {
             throw new RetentionException(ErrorCode.RETENTION_FORECAST_NOT_FOUND);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionSupportQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/query/service/RetentionSupportQueryServiceImpl.java
@@ -42,6 +42,7 @@ public class RetentionSupportQueryServiceImpl implements RetentionSupportQuerySe
         List<RetentionForecastItemDto> filtered =
             rawList.stream()
                    .map(raw -> RetentionForecastItemDto.builder()
+                       .empNo(raw.getEmpNo())
                        .empName(raw.getEmpName())
                        .deptName(raw.getDeptName())
                        .positionName(raw.getPositionName())

--- a/momentum-dao-be/src/main/resources/mappers/retention/RetentionContactMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/retention/RetentionContactMapper.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.retention.query.mapper.RetentionContactMapper">
+
+    <select id="findContacts" resultType="com.dao.momentum.retention.query.dto.response.RetentionContactItemDto">
+        SELECT
+            rc.created_at,
+            t.emp_no AS targetNo,
+            t.name AS targetName,
+            d.name AS departmentName,
+            p.name AS positionName,
+            m.name AS managerName,
+            rc.reason
+        FROM retention_contact rc
+        JOIN employee t ON rc.target_id = t.emp_id
+        JOIN employee m ON rc.manager_id = m.emp_id
+        LEFT JOIN department d ON t.dept_id = d.dept_id
+        LEFT JOIN position p ON t.position_id = p.position_id
+        WHERE rc.is_deleted = 'N'
+            <if test="req.targetNo != null">
+                AND t.emp_no = #{req.targetNo}
+            </if>
+            <if test="req.managerId != null">
+                AND rc.manager_id = #{req.managerId}
+            </if>
+            <if test="req.managerNo != null">
+                AND t.emp_no = #{req.managerNo}
+            </if>
+            <if test="req.deptId != null">
+                AND t.dept_id = #{req.deptId}
+            </if>
+            <if test="req.positionId != null">
+                AND t.position_id = #{req.positionId}
+            </if>
+            <if test="req.startDate != null">
+                AND rc.created_at &gt;= #{req.startDate}
+            </if>
+            <if test="req.endDate != null">
+                AND rc.created_at &lt;= #{req.endDate}
+            </if>
+        ORDER BY rc.created_at DESC
+        LIMIT #{req.size} OFFSET #{req.offset}
+    </select>
+
+    <select id="countContacts" resultType="int">
+        SELECT COUNT(*)
+        FROM retention_contact rc
+        JOIN employee t ON rc.target_id = t.emp_id
+        WHERE rc.is_deleted = 'N'
+            <if test="req.targetNo != null">
+                AND t.emp_no = #{req.targetNo}
+            </if>
+            <if test="req.managerId != null">
+                AND rc.manager_id = #{req.managerId}
+            </if>
+            <if test="req.managerNo != null">
+                AND t.emp_no = #{req.managerNo}
+            </if>
+            <if test="req.deptId != null">
+                AND t.dept_id = #{req.deptId}
+            </if>
+            <if test="req.positionId != null">
+                AND t.position_id = #{req.positionId}
+            </if>
+            <if test="req.startDate != null">
+                AND rc.created_at &gt;= #{req.startDate}
+            </if>
+            <if test="req.endDate != null">
+                AND rc.created_at &lt;= #{req.endDate}
+            </if>
+    </select>
+
+</mapper>

--- a/momentum-dao-be/src/main/resources/mappers/retention/RetentionContactMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/retention/RetentionContactMapper.xml
@@ -26,7 +26,7 @@
                 AND rc.manager_id = #{req.managerId}
             </if>
             <if test="req.managerNo != null">
-                AND t.emp_no = #{req.managerNo}
+                AND m.emp_no = #{req.managerNo}
             </if>
             <if test="req.deptId != null">
                 AND t.dept_id = #{req.deptId}
@@ -72,4 +72,27 @@
             </if>
     </select>
 
+    <!-- 면담 상세 조회 -->
+    <select id="findContactDetailById" resultType="com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto">
+        SELECT
+            rc.retention_id AS retentionId,
+            t.name AS targetName,
+            t.emp_no AS targetNo,
+            d.name AS deptName,
+            p.name AS positionName,
+            rc.manager_id AS managerId,
+            m.name AS managerName,
+            rc.reason,
+            rc.created_at,
+            rc.response,
+            rc.response_at,
+            rc.feedback
+        FROM retention_contact rc
+        JOIN employee t ON rc.target_id = t.emp_id
+        LEFT JOIN employee m ON rc.manager_id = m.emp_id
+        LEFT JOIN department d ON t.dept_id = d.dept_id
+        LEFT JOIN position p ON t.position_id = p.position_id
+        WHERE rc.retention_id = #{retentionId}
+            AND rc.is_deleted = 'N'
+    </select>
 </mapper>

--- a/momentum-dao-be/src/main/resources/mappers/retention/RetentionSupportMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/retention/RetentionSupportMapper.xml
@@ -8,6 +8,7 @@
     <select id="findRetentionForecasts" resultType="com.dao.momentum.retention.query.dto.request.RetentionSupportRaw">
         SELECT
             e.name AS empName,
+            e.emp_no AS empNo,
             d.name AS deptName,
             p.name AS positionName,
             rs.retention_score,
@@ -22,6 +23,9 @@
         JOIN position p ON e.position_id = p.position_id
         JOIN retention_round rr ON rs.round_id = rr.round_id
         WHERE rr.round_no = #{roundNo}
+            <if test="req.empNo != null">
+                AND t.emp_no = #{req.empNo}
+            </if>
             <if test="req.deptId != null">
                 AND e.dept_id = #{req.deptId}
             </if>
@@ -42,6 +46,9 @@
         JOIN position p ON e.position_id = p.position_id
         JOIN retention_round rr ON rs.round_id = rr.round_id
         WHERE rr.round_no = #{roundNo}
+            <if test="req.empNo != null">
+                AND t.emp_no = #{req.empNo}
+            </if>
             <if test="req.deptId != null">
                 AND e.dept_id = #{req.deptId}
             </if>

--- a/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/controller/RetentionContactQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/controller/RetentionContactQueryControllerTest.java
@@ -2,6 +2,7 @@ package com.dao.momentum.retention.query.controller;
 
 import com.dao.momentum.common.dto.Pagination;
 import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactDetailDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
 import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
 import com.dao.momentum.retention.query.service.RetentionContactQueryService;
@@ -19,8 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -122,4 +122,51 @@ class RetentionContactQueryControllerTest {
                 .andExpect(jsonPath("$.data.items[0].reason").value("복지 불만 비율이 높아짐"))
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("면담 기록 상세 조회 성공")
+    @WithMockUser(username = "34", authorities = "MANAGER")
+    void getContactDetail_success() throws Exception {
+        // given
+        Long retentionId = 1L;
+
+        RetentionContactDetailDto detail = RetentionContactDetailDto.builder()
+                .retentionId(retentionId)
+                .targetName("김예은")
+                .targetNo("20250019")
+                .deptName("영업팀")
+                .positionName("사원")
+                .managerId(34L)
+                .managerName("김하윤")
+                .reason("근속 지수가 낮아져 상담 요청이 필요합니다.")
+                .createdAt(LocalDateTime.of(2025, 6, 23, 15, 28, 18))
+                .response("업무 만족도 향상을 위한 경로 안내")
+                .responseAt(LocalDateTime.of(2025, 6, 23, 15, 28, 18))
+                .feedback("직무 재배치 검토 중")
+                .feedbackWritable(false)
+                .deletable(false)
+                .build();
+
+        Mockito.when(contactQueryService.getContactDetail(eq(retentionId), eq(34L)))
+                .thenReturn(detail);
+
+        // when & then
+        mockMvc.perform(get("/retention/contact/{retentionId}", retentionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.retentionId").value(1))
+                .andExpect(jsonPath("$.data.targetName").value("김예은"))
+                .andExpect(jsonPath("$.data.targetNo").value("20250019"))
+                .andExpect(jsonPath("$.data.deptName").value("영업팀"))
+                .andExpect(jsonPath("$.data.positionName").value("사원"))
+                .andExpect(jsonPath("$.data.managerId").value(34))
+                .andExpect(jsonPath("$.data.managerName").value("김하윤"))
+                .andExpect(jsonPath("$.data.reason").value("근속 지수가 낮아져 상담 요청이 필요합니다."))
+                .andExpect(jsonPath("$.data.response").value("업무 만족도 향상을 위한 경로 안내"))
+                .andExpect(jsonPath("$.data.feedback").value("직무 재배치 검토 중"))
+                .andExpect(jsonPath("$.data.feedbackWritable").value(false))
+                .andExpect(jsonPath("$.data.deletable").value(false))
+                .andDo(print());
+    }
+
 }

--- a/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/controller/RetentionContactQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/controller/RetentionContactQueryControllerTest.java
@@ -1,0 +1,125 @@
+package com.dao.momentum.retention.query.controller;
+
+import com.dao.momentum.common.dto.Pagination;
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
+import com.dao.momentum.retention.query.service.RetentionContactQueryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest(RetentionContactQueryController.class)
+class RetentionContactQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RetentionContactQueryService contactQueryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("면담 기록 전체 조회 성공")
+    @WithMockUser(authorities = "HR_MANAGER")
+    void getContactList_success() throws Exception {
+        // given
+        RetentionContactItemDto item = RetentionContactItemDto.builder()
+                .createdAt(LocalDateTime.of(2025, 6, 23, 15, 28, 18))
+                .empNo("20250020")
+                .targetName("이하준")
+                .deptName("프론트엔드팀")
+                .positionName("대리")
+                .managerName("정지우")
+                .reason("복지 불만 비율이 높아짐")
+                .build();
+
+        RetentionContactListResultDto resultDto = RetentionContactListResultDto.builder()
+                .items(List.of(item))
+                .pagination(Pagination.builder()
+                        .currentPage(1)
+                        .totalItems(1L)
+                        .totalPage(1)
+                        .build())
+                .build();
+
+        Mockito.when(contactQueryService.getContactList(any(RetentionContactListRequestDto.class)))
+                .thenReturn(resultDto);
+
+        // when & then
+        mockMvc.perform(get("/retention/contact")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].empNo").value("20250020"))
+                .andExpect(jsonPath("$.data.items[0].targetName").value("이하준"))
+                .andExpect(jsonPath("$.data.items[0].deptName").value("프론트엔드팀"))
+                .andExpect(jsonPath("$.data.items[0].positionName").value("대리"))
+                .andExpect(jsonPath("$.data.items[0].managerName").value("정지우"))
+                .andExpect(jsonPath("$.data.items[0].reason").value("복지 불만 비율이 높아짐"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("나에게 요청된 면담 기록 조회 성공")
+    @WithMockUser(username = "34", authorities = "MANAGER")
+    void getMyContactRequests_success() throws Exception {
+        // given
+        RetentionContactItemDto item = RetentionContactItemDto.builder()
+                .createdAt(LocalDateTime.of(2025, 6, 23, 15, 28, 18))
+                .empNo("20250020")
+                .targetName("이하준")
+                .deptName("프론트엔드팀")
+                .positionName("대리")
+                .managerName("정지우")
+                .reason("복지 불만 비율이 높아짐")
+                .build();
+
+        RetentionContactListResultDto resultDto = RetentionContactListResultDto.builder()
+                .items(List.of(item))
+                .pagination(Pagination.builder()
+                        .currentPage(1)
+                        .totalItems(1L)
+                        .totalPage(1)
+                        .build())
+                .build();
+
+        Mockito.when(contactQueryService.getMyRequestedContactList(anyLong(), any(RetentionContactListRequestDto.class)))
+                .thenReturn(resultDto);
+
+        // when & then
+        mockMvc.perform(get("/retention/contact/my")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].empNo").value("20250020"))
+                .andExpect(jsonPath("$.data.items[0].targetName").value("이하준"))
+                .andExpect(jsonPath("$.data.items[0].deptName").value("프론트엔드팀"))
+                .andExpect(jsonPath("$.data.items[0].positionName").value("대리"))
+                .andExpect(jsonPath("$.data.items[0].managerName").value("정지우"))
+                .andExpect(jsonPath("$.data.items[0].reason").value("복지 불만 비율이 높아짐"))
+                .andDo(print());
+    }
+}

--- a/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/service/RetentionContactQueryServiceImplTest.java
@@ -1,0 +1,106 @@
+package com.dao.momentum.retention.query.service;
+
+import com.dao.momentum.common.dto.Pagination;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.retention.exception.RetentionException;
+import com.dao.momentum.retention.query.dto.request.RetentionContactListRequestDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactItemDto;
+import com.dao.momentum.retention.query.dto.response.RetentionContactListResultDto;
+import com.dao.momentum.retention.query.mapper.RetentionContactMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class RetentionContactQueryServiceImplTest {
+
+    @Mock
+    private RetentionContactMapper mapper;
+
+    @InjectMocks
+    private RetentionContactQueryServiceImpl service;
+
+    private RetentionContactListRequestDto req;
+
+    @BeforeEach
+    void setUp() {
+        req = new RetentionContactListRequestDto();
+        req.setPage(1);
+        req.setSize(10);
+    }
+
+    @Test
+    @DisplayName("면담 기록 전체 조회 성공")
+    void getContactList_success() {
+        // given
+        RetentionContactItemDto item = RetentionContactItemDto.builder()
+                .createdAt(LocalDateTime.now())
+                .empNo("20250020")
+                .targetName("이하준")
+                .deptName("프론트엔드팀")
+                .positionName("대리")
+                .managerName("정지우")
+                .reason("복지 불만 비율이 높아짐")
+                .build();
+
+        when(mapper.countContacts(req)).thenReturn(1);
+        when(mapper.findContacts(req)).thenReturn(List.of(item));
+
+        // when
+        RetentionContactListResultDto result = service.getContactList(req);
+
+        // then
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getPagination().getTotalItems()).isEqualTo(1L);
+        assertThat(result.getPagination().getTotalPage()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("면담 기록 조회 실패 - 결과 NULL")
+    void getContactList_null_throwsException() {
+        when(mapper.countContacts(req)).thenReturn(1);
+        when(mapper.findContacts(req)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getContactList(req))
+                .isInstanceOf(RetentionException.class)
+                .hasMessageContaining(ErrorCode.RETENTION_CONTACT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("나에게 요청된 면담 기록 조회 성공")
+    void getMyRequestedContactList_success() {
+        Long empId = 34L;
+
+        RetentionContactItemDto item = RetentionContactItemDto.builder()
+                .createdAt(LocalDateTime.now())
+                .empNo("20250020")
+                .targetName("이하준")
+                .deptName("프론트엔드팀")
+                .positionName("대리")
+                .managerName("정지우")
+                .reason("복지 불만 비율이 높아짐")
+                .build();
+
+        req.setManagerId(empId);
+
+        when(mapper.countContacts(req)).thenReturn(1);
+        when(mapper.findContacts(req)).thenReturn(List.of(item));
+
+        RetentionContactListResultDto result = service.getMyRequestedContactList(empId, req);
+
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getManagerName()).isEqualTo("정지우");
+    }
+}

--- a/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/service/RetentionStatisticsQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/retention/query/service/RetentionStatisticsQueryServiceImplTest.java
@@ -76,7 +76,7 @@ class RetentionStatisticsQueryServiceImplTest {
         raw.setUnstableCount(2L);
         raw.setTotalCount(10L);
 
-        when(mapper.findStabilityDistributionByDept(2025)).thenReturn(List.of(raw));
+        when(mapper.findStabilityDistributionByDept(req)).thenReturn(List.of(raw));
 
         // when
         List<StabilityDistributionByDeptDto> result = service.getStabilityDistributionByDept(req);
@@ -96,13 +96,14 @@ class RetentionStatisticsQueryServiceImplTest {
         RetentionStatisticsRequestDto req = new RetentionStatisticsRequestDto();
         req.setYear(2025);
 
-        when(mapper.findStabilityDistributionByDept(2025)).thenReturn(null);
+        when(mapper.findStabilityDistributionByDept(req)).thenReturn(null);
 
         // when & then
         assertThatThrownBy(() -> service.getStabilityDistributionByDept(req))
                 .isInstanceOf(RetentionException.class)
                 .hasMessageContaining(ErrorCode.RETENTION_FORECAST_NOT_FOUND.getMessage());
     }
+
 
     @Test
     @DisplayName("getOverallStabilityDistribution - 전체 조회 성공")


### PR DESCRIPTION
closes #94 
closes #95
closes #196
---

📌 개요

🔨 주요 변경 사항
- RetentionContactQueryController
- RetentionForecastRequestDto
- RetentionContactItemDto
- RetentionContactListResultDto
- RetentionContactMapper
- RetentionContactQueryService
- RetentionContactQueryServiceImpl
- RetentionContactMapper
- RetentionContactQueryControllerTest
- RetentionContactQueryServiceImplTest


✅ 리뷰 요청 사항

⭐ 관련 이슈
#
