### PR TITLE
feat: 사원 CSV 등록 기능 구현

### DIFF
--- a/momentum-dao-be/build.gradle
+++ b/momentum-dao-be/build.gradle
@@ -71,6 +71,10 @@ dependencies {
 
     // Kafka 클라이언트 라이브러리 의존성 추가
     implementation 'org.springframework.kafka:spring-kafka'
+
+    // csv import 라이브러리
+    // https://mvnrepository.com/artifact/com.opencsv/opencsv
+    implementation 'com.opencsv:opencsv:5.11.1'
 }
 
 tasks.named('test') {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum ErrorCode {
-    //사원 오류(10001 - 199999)
+    //사원 오류(10001 - 10999)
     EMPLOYEE_ALREADY_EXISTS("10001", "해당 사원이 이미 존재합니다.",HttpStatus.CONFLICT),
     EMPLOYEE_NOT_FOUND("10002","해당 사원을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
     INVALID_CREDENTIALS("10003","유효하지 않은 입력입니다. 다시 입력해주세요",HttpStatus.NOT_FOUND),
@@ -35,6 +35,16 @@ public enum ErrorCode {
     INVALID_CONTRACT("12002", "연봉계약서가 아닌 경우 연봉을 작성할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ATTACHMENT_REQUIRED("12003", "첨부파일이 없습니다.", HttpStatus.BAD_REQUEST), CONTRACT_NOT_FOUND("12004", "해당 계약서를 찾을 수 없습니다." , HttpStatus.NOT_FOUND),
     ATTACHMENT_NOT_FOUND("12004", "첨부파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // CSV 오류 (13001 - 13999)
+    CSV_NOT_FOUND("13001", "CSV 파일이 존재하지 않습니다." , HttpStatus.BAD_REQUEST),
+    NOT_A_CSV("13002", "CSV 파일이 아닙니다.", HttpStatus.BAD_REQUEST),
+    EMPTY_DATA_PROVIDED("13003", "입력할 데이터가 없습니다." , HttpStatus.BAD_REQUEST),
+    CSV_READ_FAILED("13004", "CSV 파일을 읽는 데 실패했습니다." , HttpStatus.BAD_REQUEST),
+    INVALID_CSV_HEADER("13005", "CSV 헤더가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COLUMN_COUNT("13006", "[%d행] 컬럼 수(%d)가 헤더(%d)와 다릅니다.", HttpStatus.BAD_REQUEST),
+    REQUIRED_VALUE_NOT_FOUND("13007", "[%d행] '%s' 필드는 필수 입력입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_STATUS("13008", "존재하지 않는 재직 상태입니다." , HttpStatus.BAD_REQUEST),
 
     // 출퇴근 오류
     WORKTYPE_NOT_FOUND("20001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.dao.momentum.approve.exception.NotExistTabException;
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.organization.contract.exception.ContractException;
 import com.dao.momentum.email.exception.EmailFailException;
+import com.dao.momentum.organization.employee.exception.EmployeeException;
 import com.dao.momentum.work.exception.WorkException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -33,6 +34,16 @@ public class GlobalExceptionHandler {
 
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(EmployeeException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEmployeeException(EmployeeException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), e.getMessage());
 
         return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/application/service/FileService.java
@@ -30,7 +30,8 @@ public class FileService {
                 "pdf", "docx", "txt",   // 문서
                 "hwp", "hwpx",          // 한글
                 "xlsx", "xls",          // 엑셀
-                "pptx", "ppt"           // 파워포인트
+                "pptx", "ppt",           // 파워포인트
+                "csv" // csv
         ).contains(extension)) {
             throw new FileUploadFailedException(ErrorCode.INVALID_FILE_EXTENSION);
         }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
@@ -1,11 +1,12 @@
 package com.dao.momentum.organization.department.command.domain.repository;
 
 import com.dao.momentum.organization.department.command.domain.aggregate.Department;
+import com.dao.momentum.organization.department.command.domain.aggregate.IsDeleted;
 
 import java.util.Optional;
 
 public interface DepartmentRepository {
     Optional<Department> findById(int deptId);
 
-    Optional<Department> findByName(String deptName);
+    Optional<Department> findByNameAndIsDeleted(String deptName, IsDeleted isDeleted);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface DepartmentRepository {
     Optional<Department> findById(int deptId);
+
+    Optional<Department> findByName(String deptName);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/controller/EmployeeCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/controller/EmployeeCommandController.java
@@ -44,14 +44,17 @@ public class EmployeeCommandController {
     // csv는 DB 저장 안하고 백엔드에 하드코딩
     @Operation(summary = "사원 CSV 등록", description = "관리자는 CSV 파일을 업로드하여 사원을 일괄 등록할 수 있다.")
     @PostMapping("/csv")
-    public ResponseEntity<ApiResponse<EmployeeCSVResponse>> createEmployees(@RequestParam("file") MultipartFile file){
+    public ResponseEntity<ApiResponse<EmployeeCSVResponse>> createEmployees(
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
 
         if (file.isEmpty()) {
             throw new EmployeeException(ErrorCode.CSV_NOT_FOUND);
         }
         validateFileType(file);
 
-        EmployeeCSVResponse response = employeeService.createEmployees(file);
+        EmployeeCSVResponse response = employeeService.createEmployees(file, userDetails);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -64,7 +67,6 @@ public class EmployeeCommandController {
             throw new EmployeeException(ErrorCode.NOT_A_CSV);
         }
     }
-
 
     @Operation(summary = "사원 기본 정보 수정", description = "관리자는 사원의 사번, 재직 상태, 이메일을 수정할 수 있다.")
     @PutMapping("/{empId}")

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/controller/EmployeeCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/controller/EmployeeCommandController.java
@@ -1,25 +1,31 @@
 package com.dao.momentum.organization.employee.command.application.controller;
 
 import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.common.exception.ErrorCode;
 import com.dao.momentum.organization.employee.command.application.dto.request.AppointCreateRequest;
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeInfoUpdateRequest;
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeRecordsUpdateRequest;
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeRegisterRequest;
 import com.dao.momentum.organization.employee.command.application.dto.response.AppointCreateResponse;
+import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeCSVResponse;
 import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeInfoUpdateResponse;
 import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeRecordsUpdateResponse;
 import com.dao.momentum.organization.employee.command.application.service.EmployeeCommandService;
+import com.dao.momentum.organization.employee.exception.EmployeeException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/employees")
@@ -34,6 +40,31 @@ public class EmployeeCommandController {
         employeeService.createEmployee(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
     }
+
+    // csv는 DB 저장 안하고 백엔드에 하드코딩
+    @Operation(summary = "사원 CSV 등록", description = "관리자는 CSV 파일을 업로드하여 사원을 일괄 등록할 수 있다.")
+    @PostMapping("/csv")
+    public ResponseEntity<ApiResponse<EmployeeCSVResponse>> createEmployees(@RequestParam("file") MultipartFile file){
+
+        if (file.isEmpty()) {
+            throw new EmployeeException(ErrorCode.CSV_NOT_FOUND);
+        }
+        validateFileType(file);
+
+        EmployeeCSVResponse response = employeeService.createEmployees(file);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    private void validateFileType(MultipartFile file) {
+        String filename = file.getOriginalFilename();
+        log.info("Uploaded Content-Type: {}", file.getContentType());
+
+        if (filename == null || !filename.toLowerCase().endsWith(".csv")) {
+            throw new EmployeeException(ErrorCode.NOT_A_CSV);
+        }
+    }
+
 
     @Operation(summary = "사원 기본 정보 수정", description = "관리자는 사원의 사번, 재직 상태, 이메일을 수정할 수 있다.")
     @PutMapping("/{empId}")
@@ -75,6 +106,5 @@ public class EmployeeCommandController {
                 )
         );
     }
-
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/dto/response/EmployeeCSVResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/dto/response/EmployeeCSVResponse.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.organization.employee.command.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class EmployeeCSVResponse {
+    private List<Long> empIds;
+
+    private String message;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/service/EmployeeCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/application/service/EmployeeCommandService.java
@@ -11,10 +11,7 @@ import com.dao.momentum.organization.employee.command.application.dto.request.Ap
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeInfoUpdateRequest;
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeRecordsUpdateRequest;
 import com.dao.momentum.organization.employee.command.application.dto.request.EmployeeRegisterRequest;
-import com.dao.momentum.organization.employee.command.application.dto.response.AppointCreateResponse;
-import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeInfoDTO;
-import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeInfoUpdateResponse;
-import com.dao.momentum.organization.employee.command.application.dto.response.EmployeeRecordsUpdateResponse;
+import com.dao.momentum.organization.employee.command.application.dto.response.*;
 import com.dao.momentum.organization.employee.command.domain.aggregate.*;
 import com.dao.momentum.organization.employee.command.domain.repository.*;
 import com.dao.momentum.organization.employee.exception.EmployeeException;
@@ -22,6 +19,8 @@ import com.dao.momentum.organization.position.command.domain.aggregate.IsDeleted
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import com.dao.momentum.organization.position.command.domain.repository.PositionRepository;
 import com.dao.momentum.organization.position.exception.PositionException;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -30,7 +29,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -358,6 +363,186 @@ public class EmployeeCommandService {
         if (position.getIsDeleted() == IsDeleted.Y) {
             throw new EmployeeException(ErrorCode.POSITION_NOT_FOUND);
         }
+    }
+
+    @Transactional
+    public EmployeeCSVResponse createEmployees(MultipartFile file) {
+        // 1) 파싱 & 검증
+        List<Employee> entities = parseAndValidate(file);
+
+        // 2) 저장
+        entities.forEach(employeeRepository::save);
+
+        // 3) 응답 DTO 반환
+        return EmployeeCSVResponse.builder()
+                .empIds(entities.stream().map(Employee::getEmpId).toList())
+                .message("사원 CSV 등록 성공")
+                .build();
+    }
+
+    /**
+     * CSV 파싱 → 검증 → Entity 리스트 반환
+     */
+    public List<Employee> parseAndValidate(MultipartFile file) {
+        List<String[]> rows = readAllRows(file);
+
+        String[] header = rows.get(0);
+        validateHeader(header);
+
+        List<Employee> entities = new ArrayList<>();
+        for (int i = 1; i < rows.size(); i++) {
+            int line = i + 1;
+            String[] cols = rows.get(i);
+
+            if (isEmptyRow(cols)) continue; // ",,,,," 행이 남아있으면 무시
+
+            validateRow(cols, header, line);
+            entities.add(toEntity(cols));
+        }
+        return entities;
+    }
+
+    // BOM 처리
+    private String normalize(String s) {
+        return s == null
+                ? null
+                : s.replace("\uFEFF", "").trim();
+    }
+
+    private boolean isEmptyRow(String[] cols) {
+        return cols == null || Arrays.stream(cols).allMatch(c -> c == null || c.isBlank());
+    }
+
+    // 1) 전체 행 읽기
+    private List<String[]> readAllRows(MultipartFile file) {
+        try (
+                InputStream is = file.getInputStream();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                CSVReader csv = new CSVReader(reader)
+        ) {
+            List<String[]> rows = csv.readAll();
+            if (rows.isEmpty()) {
+                throw new EmployeeException(ErrorCode.EMPTY_DATA_PROVIDED);
+            }
+            return rows;
+        } catch (IOException e) {
+            throw new EmployeeException(ErrorCode.CSV_READ_FAILED, e);
+        } catch (CsvException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // 2) 헤더 검증
+    private void validateHeader(String[] header) {
+        String[] expected = {
+                "사번","이름","이메일 주소","부서명","직위명",
+                "성별","주소","연락처","입사일","상태",
+                "생년월일","잔여 연차 시간","잔여 리프레시 휴가 일수"
+        };
+
+        String[] cleaned = Arrays.stream(header)
+                .map(this::normalize)
+                .toArray(String[]::new);
+
+        if (!Arrays.equals(expected, cleaned)) {
+            throw new EmployeeException(ErrorCode.INVALID_CSV_HEADER);
+        }
+    }
+
+    // 3) 각 행 검증
+    private void validateRow(String[] cols, String[] header, int line) {
+        if (cols.length != header.length) {
+            throw new EmployeeException(
+                    ErrorCode.INVALID_COLUMN_COUNT,
+                    line, cols.length, header.length
+            );
+        }
+        for (int idx = 0; idx < cols.length; idx++) {
+            if (idx == 0 || idx == 3 || idx == 8 || idx == 9) continue;
+            if (cols[idx] == null || cols[idx].isBlank()) {
+                throw new EmployeeException(
+                        ErrorCode.REQUIRED_VALUE_NOT_FOUND,
+                       line, header[idx]
+                );
+            }
+        }
+    }
+
+    // 4) Entity 변환
+    private Employee toEntity(String[] cols) {
+        String empNo = provideDefaultEmpNo(cols[0]);
+
+        String deptName = cols[3];
+        Integer deptId = parseDeptId(deptName);
+
+        String positionName = cols[4];
+        int positionId = parsePositionId(positionName);
+
+        LocalDate joinDate = provideDefaultJoinDate(cols[8]);
+
+        Status status = parseStatus(cols[9]);
+
+        return  Employee.builder()
+                .empNo(empNo)
+                .name(cols[1])
+                .email(cols[2])
+                .password(passwordEncoder.encode(generateRandomPassword()))
+                .deptId(deptId)
+                .positionId(positionId)
+                .gender(Gender.valueOf(cols[5]))
+                .address(cols[6])
+                .contact(cols[7])
+                .joinDate(joinDate)
+                .status(status)
+                .birthDate(LocalDate.parse(cols[10]))
+                .remainingDayoffHours(Integer.parseInt(cols[11]))
+                .remainingRefreshDays(Integer.parseInt(cols[12]))
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private String provideDefaultEmpNo(String empNo) {
+        if (empNo == null || empNo.isBlank()) {
+            return generateNextEmpNo();
+        }
+        return empNo;
+    }
+
+    private Integer parseDeptId(String deptName) {
+        Integer deptId = null;
+        if (deptName != null && !deptName.isBlank()) {
+            Department dept = departmentRepository.findByName(deptName)
+                    .orElseThrow(() -> new DepartmentException(ErrorCode.DEPARTMENT_NOT_FOUND));
+            deptId = dept.getDeptId();
+        }
+        return deptId;
+    }
+
+    private int parsePositionId(String positionName) {
+        Position position = positionRepository.findByName(positionName)
+                .orElseThrow(() -> new PositionException(ErrorCode.POSITION_NOT_FOUND));
+       return position.getPositionId();
+    }
+
+    private LocalDate provideDefaultJoinDate(String input) {
+        LocalDate joinDate = LocalDate.now();
+        if (input != null && !input.isBlank()) {
+            joinDate = LocalDate.parse(input);
+        }
+        return joinDate;
+    }
+
+    private Status parseStatus(String input) {
+        if (input == null) {
+            return Status.EMPLOYED;
+        }
+
+        return switch (input) {
+            case "", "재직" -> Status.EMPLOYED;
+            case "휴직" -> Status.ON_LEAVE;
+            case "퇴사" -> Status.RESIGNED;
+            default -> throw new EmployeeException(ErrorCode.INVALID_STATUS);
+        };
     }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/exception/EmployeeException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/exception/EmployeeException.java
@@ -11,4 +11,9 @@ public class EmployeeException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public EmployeeException(ErrorCode errorCode, Object... args) {
+        super(String.format(errorCode.getMessage(), args));
+        this.errorCode = errorCode;
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
@@ -27,4 +27,6 @@ public interface PositionRepository {
     void decrementLevelsInRange(int startLevel, int endLevel);
 
     void deleteByPositionId(Integer positionId);
+
+    Optional<Position> findByName(String positionName);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/position/command/domain/repository/PositionRepository.java
@@ -1,9 +1,8 @@
 package com.dao.momentum.organization.position.command.domain.repository;
 
+import com.dao.momentum.organization.position.command.domain.aggregate.IsDeleted;
 import com.dao.momentum.organization.position.command.domain.aggregate.Position;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -28,5 +27,5 @@ public interface PositionRepository {
 
     void deleteByPositionId(Integer positionId);
 
-    Optional<Position> findByName(String positionName);
+    Optional<Position> findByNameAndIsDeleted(String positionName, IsDeleted isDeleted);
 }


### PR DESCRIPTION
closes #37 

---

📌 개요
- 사원 CSV 등록 기능 구현

🔨 주요 변경 사항
- opencsv 의존성 추가 (build.gradle 변경)
- presigned-url 요청에 csv 파일 허용
- 컨트롤러, 서비스 메서드, dto 추가

- 추후 개선 가능 사항: 권한도 CSV 일괄 등록 가능하게
(학력 등은 필드가 많은 1대 다라 어려울 듯. 필요하면 그쪽에도 CSV 등록 기능 지원 필요)

✅ 리뷰 요청 사항
- employee 생성 로직 적절한지

⭐ 관련 이슈
#37 
