### PR TITLE
feat: 비밀번호 변경 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/controller/AuthController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/controller/AuthController.java
@@ -2,9 +2,11 @@ package com.dao.momentum.common.auth.application.controller;
 
 
 import com.dao.momentum.common.auth.application.dto.request.LoginRequest;
+import com.dao.momentum.common.auth.application.dto.request.PasswordChangeRequest;
 import com.dao.momentum.common.auth.application.dto.request.PasswordResetLinkRequest;
 import com.dao.momentum.common.auth.application.dto.request.PasswordResetRequest;
 import com.dao.momentum.common.auth.application.dto.response.LoginResponse;
+import com.dao.momentum.common.auth.application.dto.response.PasswordChangeResponse;
 import com.dao.momentum.common.auth.application.dto.response.PasswordResetResponse;
 import com.dao.momentum.common.auth.application.dto.response.TokenResponse;
 import com.dao.momentum.common.auth.application.service.AuthService;
@@ -16,6 +18,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
@@ -90,6 +94,18 @@ public class AuthController {
 
         return ResponseEntity.ok().body(ApiResponse.success(response));
     }
+
+    @Operation(summary = "비밀번호 변경", description = "사원은 권한이 있는 상태에서 자신의 비밀번호를 변경할 수 있다. 비밀번호, 확인 비밀번호를 필요로 한다.")
+    @PostMapping("/change-password")
+    public ResponseEntity<ApiResponse<PasswordChangeResponse>> changePassword(
+            @AuthenticationPrincipal UserDetails username,
+            @RequestBody @Valid PasswordChangeRequest request
+    ) {
+        PasswordChangeResponse response = authService.changePassword(username,request);
+
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/dto/request/PasswordChangeRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,28 @@
+package com.dao.momentum.common.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PasswordChangeRequest {
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~])[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~]{8,}$",
+            message = "비밀번호는 8자 이상이며, 영문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+    )
+    private String password;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~])[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~]{8,}$",
+            message = "비밀번호는 8자 이상이며, 영문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+    )
+    private String verifiedPassword;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/dto/response/PasswordChangeResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/auth/application/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.common.auth.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PasswordChangeResponse {
+    private String message;
+}


### PR DESCRIPTION
closes #114 

---

📌 개요
- 비밀번호 변경 기능 구현
- 사원은 현재 비밀번호, 새로운 비밀번호, 비밀번호 확인을 입력하여 비밀번호를 변경할 수 있다.

🔨 주요 변경 사항
- AuthController 및 AuthService 비밀번호 변경 메소드 구현
- /employees/change-password 엔드포인트 설정

✅ 리뷰 요청 사항
- 비밀번호 변경 기능 로직 확인

⭐ 관련 이슈
#114 
