### PR TITLE
refactor : 영수증 결재 내역에 주소 컬럼 추가 및 mapper 쿼리 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveReceiptDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/ApproveReceiptDTO.java
@@ -2,7 +2,7 @@ package com.dao.momentum.approve.query.dto.approveTypeDTO;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @ToString
@@ -13,7 +13,8 @@ public class ApproveReceiptDTO {
 
     private String receiptType;
     private String storeName;
+    private String storeAddress;
     private Integer amount;
-    private LocalDateTime usedAt;
+    private LocalDate usedAt;
 
 }

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -86,6 +86,7 @@
         SELECT
             receipt_type,
             store_name,
+            store_address,
             amount,
             used_at
         FROM approve_receipt


### PR DESCRIPTION
closes #8
---

📌 개요
영수증 결재 내역에 주소 컬럼 추가 및 mapper 쿼리 수정

🔨 주요 변경 사항
- `ApproveReceiptDTO`(영수증 결재 내역 DTO)에 **storeAddress** 추가
- `ApproveDetailMapper`에 getReceiptDetail메서드에 **store_address** 컬럼 추가
✅ 리뷰 요청 사항

⭐ 관련 이슈
#8
