### PR TITLE
feat : 결재 문서 작성 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
@@ -1,12 +1,17 @@
 package com.dao.momentum.approve.command.application.controller;
 
+import com.dao.momentum.approve.command.application.dto.request.ApproveRequest;
 import com.dao.momentum.approve.command.application.dto.response.ReceiptOcrResultResponse;
+import com.dao.momentum.approve.command.application.service.ApproveCommandService;
 import com.dao.momentum.approve.command.application.service.OcrService;
 import com.dao.momentum.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ApproveCommandController {
 
     private final OcrService ocrService;
+    private final ApproveCommandService approveCommandService;
 
     @PostMapping("/ocr/receipt")
     @Operation(summary = "영수증 내용 추출하기", description = "ocr api를 이용해 영수증 내용을 추출합니다.")
@@ -27,5 +33,20 @@ public class ApproveCommandController {
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
+    @PostMapping("/documents")
+    @Operation(summary = "결재 작성 하기", description = "사원이 결재 서류를 작성합니다.")
+    public ResponseEntity<ApiResponse<Void>> createApprovalDocument (
+            @RequestBody @Valid ApproveRequest approveRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        approveCommandService.createApproval(approveRequest, empId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineListRequest.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.approve.command.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveLineListRequest {
+
+    @NotNull(message = "상태 아이디는 null일 수 없습니다.")
+    private final Integer statusId;
+
+    @NotNull(message = "사원 아이디는 null일 수 없습니다.")
+    private final Long empId;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineRequest.java
@@ -1,0 +1,25 @@
+package com.dao.momentum.approve.command.application.dto.request;
+
+import com.dao.momentum.approve.command.domain.aggregate.IsRequiredAll;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveLineRequest {
+
+    @NotNull(message = "상태 아이디는 null일 수 없습니다.")
+    private final Integer statusId;
+
+    @NotNull(message = "결재선 순서는 null일 수 없습니다.")
+    private final Integer approveLineOrder;
+
+    private final IsRequiredAll isRequiredAll;
+
+    private final List<ApproveLineListRequest> approveLineList;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRefRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRefRequest.java
@@ -1,0 +1,21 @@
+package com.dao.momentum.approve.command.application.dto.request;
+
+import com.dao.momentum.approve.command.domain.aggregate.IsConfirmed;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveRefRequest {
+
+    @NotBlank(message = "사원 id는 null일 수 없습니다.")
+    private final Long empId;
+
+    @NotNull
+    private final IsConfirmed isConfirmed;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRequest.java
@@ -1,0 +1,40 @@
+package com.dao.momentum.approve.command.application.dto.request;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveRequest {
+
+    private final Long parentApproveId;
+
+    @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+    private final String approveTitle;
+
+    @NotNull
+    private final ApproveType approveType;
+
+    // 결재선
+    private final List<ApproveLineRequest> approveLineLists;
+
+    // 참조하는 사람
+    private final List<ApproveRefRequest> refRequests;
+
+    // 결재 문서가 많아서 이것을 DTO로 통합하기 어려움
+    // 그래서 json 형식으로 폼을 저장한 뒤에 나중에 DTO 객체로 변환해서 사용함
+    private final JsonNode formDetail;
+
+    @Valid
+    private final List<AttachmentRequest> attachments; // S3에 미리 업로드된 파일 정보 전달
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveCancelRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveCancelRequest.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveCancelRequest {
+
+    @NotBlank(message="취소 사유는 반드시 입력해야 합니다.")
+    private final String cancelReason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveProposalRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveProposalRequest.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ApproveProposalRequest {
+
+    @NotBlank(message="품의 내용은 반드시 입력해야 합니다.")
+    private final String content;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveReceiptRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveReceiptRequest.java
@@ -1,0 +1,31 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import com.dao.momentum.approve.command.domain.aggregate.ReceiptType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class ApproveReceiptRequest {
+
+    @NotNull(message="영수증 종류는 반드시 선택해야 합니다.")
+    private final ReceiptType receiptType;
+
+    @NotBlank(message = "가게 이름은 반드시 작성해야 합니다.")
+    private final String storeName;
+
+    private final int amount;
+
+    @NotBlank(message="가게 주소는 반드시 작성해야 합니다.")
+    private final String address;
+
+    @NotNull(message="사용한 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate usedAt;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/BusinessTripRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/BusinessTripRequest.java
@@ -1,0 +1,32 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import com.dao.momentum.work.command.domain.aggregate.TypeEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class BusinessTripRequest {
+
+    @NotNull(message="출장 종류는 반드시 선택해야 합니다.")
+    private final TypeEnum type;
+
+    @NotBlank(message="출장 장소는 반드시 작성해야 합니다.")
+    private final String place;
+
+    @NotNull(message="출장 시작 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate startDate;
+
+    @NotNull(message="출장 종료 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate endDate;
+
+    @NotNull(message="출장 사유는 반드시 작성해야 합니다.")
+    private final String reason;
+
+    private final int cost;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
@@ -18,7 +18,7 @@ public class OvertimeRequest {
 
     private final int breakTime;
 
-    @NotNull(message="출장 이유는 반드시 작성해야 합니다.")
+    @NotNull(message="초과 근무 사유는 반드시 작성해야 합니다.")
     private final String reason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
@@ -1,0 +1,24 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class OvertimeRequest {
+
+    @NotNull(message="초과 근무 시작 시간은 반드시 작성해야 합니다.")
+    private final LocalDateTime startAt;
+
+    @NotNull(message="초과 근무 종료 시간은 반드시 작성해야 합니다.")
+    private final LocalDateTime endAt;
+
+    private final int breakTime;
+
+    @NotNull(message="출장 이유는 반드시 작성해야 합니다.")
+    private final String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/RemoteWorkRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/RemoteWorkRequest.java
@@ -1,0 +1,21 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class RemoteWorkRequest {
+
+    @NotNull(message="재택 근무 시작 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate startDate;
+
+    @NotNull(message="재택 근무 종료 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate endDate;
+
+    private final String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/VacationRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/VacationRequest.java
@@ -1,0 +1,23 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class VacationRequest {
+
+    private final int vacationTypeId;
+
+    @NotNull(message="휴가 시작 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate startDate;
+
+    @NotNull(message="휴가 종료 날짜는 반드시 작성해야 합니다.")
+    private final LocalDate endDate;
+
+    private final String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
@@ -1,0 +1,31 @@
+package com.dao.momentum.approve.command.application.dto.request.approveType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class WorkCorrectionRequest {
+
+    @NotNull(message="정정하고자 하는 근무 번호는 반드시 입력해야 합니다.")
+    private final Long workId;
+
+    @NotNull(message="기존 출근 일시는 반드시 작성해야 합니다.")
+    private final LocalDateTime beforeStartAt;
+
+    @NotNull(message="기존 퇴근 일시는 반드시 작성해야 합니다.")
+    private final LocalDateTime beforeEndAt;
+
+    @NotNull(message="수정 출근 일시는 반드시 작성해야 합니다.")
+    private final LocalDateTime afterStartAt;
+
+    @NotNull(message="수정 퇴근 일시는 반드시 작성해야 합니다.")
+    private final LocalDateTime afterEndAt;
+
+    @NotNull(message="출퇴근 정정 사유는 반드시 작성해야 합니다.")
+    private final String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class WorkCorrectionRequest {
 
-    @NotNull(message="정정하고자 하는 근무 번호는 반드시 입력해야 합니다.")
+    @NotNull(message="정정하고자 하는 근무 번호는 반드시 선택해야 합니다.")
     private final Long workId;
 
     @NotNull(message="기존 출근 일시는 반드시 작성해야 합니다.")

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.application.dto.request.ApproveRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ApproveCommandService {
+
+    void createApproval(ApproveRequest approveRequest, Long empId);
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
@@ -1,0 +1,143 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.application.dto.request.*;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategyDispatcher;
+import com.dao.momentum.approve.command.domain.aggregate.*;
+import com.dao.momentum.approve.command.domain.repository.*;
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
+import com.dao.momentum.file.command.domain.aggregate.File;
+import com.dao.momentum.file.command.domain.repository.FileRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ApproveCommandServiceImpl implements ApproveCommandService{
+
+    private final FormDetailStrategyDispatcher formDetailStrategyDispatcher;
+    private final ApproveRepository approveRepository;
+    private final ApproveLineRepository approveLineRepository;
+    private final ApproveLineListRepository approveLineListRepository;
+    private final ApproveRefRepository approveRefRepository;
+    private final FileRepository fileRepository;
+
+    @Transactional
+    public void createApproval(ApproveRequest approveRequest, Long empId) {
+        // ApproveRequest 에 들어 있는 값 가져오기
+        Long parentApproveId = approveRequest.getParentApproveId();
+        ApproveType approveType = approveRequest.getApproveType();
+        String title = approveRequest.getApproveTitle();
+        JsonNode form = approveRequest.getFormDetail();
+
+        log.info("결재 종류 : {}", approveType);
+        log.info("결재 문제 제목 : {}", title);
+        log.info("결재 문서 내용 : {}", form);
+
+        // 취소 요청인 경우에는 parentApproveId가 있어야 함
+        if(approveType == ApproveType.CANCEL) {
+            if(parentApproveId == null) {
+                throw new ApproveException(ErrorCode.PARENT_APPROVE_ID_REQUIRED);
+            }
+        }
+
+        // 1. 결재 생성하기
+        Approve approve = Approve.builder()
+                .parentApproveId(parentApproveId)
+                .approveTitle(title)
+                .approveType(approveType)
+                .empId(empId)
+                .build();
+
+        approveRepository.save(approve);
+
+        Long approveId = approve.getApproveId(); // 결재 아이디
+
+        log.info("결재 아이디 : {}", approveId);
+
+        // 2. 결재 문서 저장하기
+        // 어떤 결재 문서로 저장할지 결정하기
+        FormDetailStrategy strategy = formDetailStrategyDispatcher.dispatch(approveType);
+
+        strategy.saveDetail(form, approveId);
+
+        // 3.첨부파일 S3 업로드 및 DB 저장
+        List<AttachmentRequest> attachments = approveRequest.getAttachments();
+
+        if (attachments != null && !attachments.isEmpty()) {
+            for (AttachmentRequest attachment : attachments) {
+                File file = File.builder()
+                        .announcementId(null)
+                        .approveId(approveId)
+                        .contractId(null)
+                        .s3Key(attachment.getS3Key()) // 이미 S3 업로드된 URL
+                        .type(attachment.getType())
+                        .build();
+                fileRepository.save(file);
+            }
+        }
+
+        // 4. 결재선 저장하기
+        createApproveLine(approveId, approveRequest.getApproveLineLists());
+
+        // 5. 참조인 저장하기
+        List<ApproveRefRequest> approveRefRequests =
+                Optional.ofNullable(approveRequest.getRefRequests()).orElse(List.of());
+
+        if (!approveRefRequests.isEmpty()) {
+            createApproveRef(approveId, approveRefRequests);
+        }
+
+    }
+
+    // 결재선 생성하기 (결재선, 결재자 목록)
+    private void createApproveLine(Long approveId, List<ApproveLineRequest> approveLineRequests) {
+        // 결재선은 여러 개 존재하기 때문에 반복문을 이용해 저장
+        for (ApproveLineRequest lineRequest : approveLineRequests) {
+            // 결재선 생성 후 저장하기
+            ApproveLine approveLine = ApproveLine.builder()
+                    .approveId(approveId)
+                    .approveLineOrder(lineRequest.getApproveLineOrder())
+                    .isRequiredAll(lineRequest.getIsRequiredAll())
+                    .build();
+
+            approveLineRepository.save(approveLine);
+
+            Long approveLineId = approveLine.getId();
+
+            // 결재자 목록 저장하기
+            for (ApproveLineListRequest listRequest : lineRequest.getApproveLineList()) {
+                ApproveLineList lineList = ApproveLineList.builder()
+                        .approveLineId(approveLineId)
+                        .empId(listRequest.getEmpId())
+                        .build();
+
+                approveLineListRepository.save(lineList);
+            }
+        }
+    }
+
+    // 참조인 생성하기
+    private void createApproveRef(Long approveId, List<ApproveRefRequest> approveRefRequests) {
+        // 참조인은 여러명 이기 때문에 반복문을 이용해 저장
+        for (ApproveRefRequest refRequest : approveRefRequests) {
+            ApproveRef approveRef = ApproveRef.builder()
+                    .approveId(approveId)
+                    .empId(refRequest.getEmpId())
+                    .isConfirmed(IsConfirmed.N)
+                    .build();
+
+            approveRefRepository.save(approveRef);
+        }
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/FormDetailStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/FormDetailStrategy.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.application.service.strategy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface FormDetailStrategy {
+
+    void saveDetail(JsonNode form, Long approveId);
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/FormDetailStrategyDispatcher.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/FormDetailStrategyDispatcher.java
@@ -1,0 +1,37 @@
+package com.dao.momentum.approve.command.application.service.strategy;
+
+import com.dao.momentum.approve.command.application.service.strategy.form.*;
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
+import com.dao.momentum.approve.exception.NotFoundApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/* 결재 폼을 분배 해주는 클래스 (전략을 결정하는 클래스) */
+@Component
+@RequiredArgsConstructor
+public class FormDetailStrategyDispatcher {
+
+    private final BusinessTripFormStrategy businessTripFormStrategy;
+    private final CancelFormStrategy cancelFormStrategy;
+    private final OvertimeFormStrategy overtimeFormStrategy;
+    private final ProposalFormStrategy proposalFormStrategy;
+    private final RemoteWorkFormStrategy remoteWorkFormStrategy;
+    private final VacationFormStrategy vacationFormStrategy;
+    private final WorkCorrectionFormStrategy workCorrectionFormStrategy;
+    private final ReceiptFormStrategy receiptFormStrategy;
+
+    public FormDetailStrategy dispatch(ApproveType type) {
+        return switch (type) {
+            case BUSINESSTRIP -> businessTripFormStrategy;
+            case CANCEL -> cancelFormStrategy;
+            case OVERTIME -> overtimeFormStrategy;
+            case REMOTEWORK -> remoteWorkFormStrategy;
+            case VACATION -> vacationFormStrategy;
+            case WORKCORRECTION -> workCorrectionFormStrategy;
+            case PROPOSAL -> proposalFormStrategy;
+            case RECEIPT -> receiptFormStrategy;
+            default -> throw new NotFoundApproveException(ErrorCode.NOT_EXIST_APPROVE);
+        };
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/BusinessTripFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/BusinessTripFormStrategy.java
@@ -1,0 +1,40 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.BusinessTripRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.work.command.domain.aggregate.BusinessTrip;
+import com.dao.momentum.work.command.domain.repository.BusinessTripRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BusinessTripFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final BusinessTripRepository businessTripRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // BusinessTripRequest로 변환하기
+        BusinessTripRequest detail = objectMapper.convertValue(
+                form, BusinessTripRequest.class
+        );
+
+        // ApproveProposal 만들기
+        BusinessTrip businessTrip = BusinessTrip.builder()
+                .approveId(approveId)
+                .type(detail.getType())
+                .place(detail.getPlace())
+                .startDate(detail.getStartDate())
+                .endDate(detail.getEndDate())
+                .reason(detail.getReason())
+                .cost(detail.getCost())
+                .build();
+
+        // 저장하기
+        businessTripRepository.save(businessTrip);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/CancelFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/CancelFormStrategy.java
@@ -1,0 +1,35 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.ApproveCancelRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.domain.aggregate.ApproveCancel;
+import com.dao.momentum.approve.command.domain.repository.ApproveCancelRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CancelFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final ApproveCancelRepository approveCancelRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // json 형식의 폼을 ApproveCancelRequest 타입으로 변경
+        ApproveCancelRequest detail = objectMapper.convertValue(
+                form, ApproveCancelRequest.class
+        );
+
+        // ApproveCancel 만들기
+        ApproveCancel approveCancel = ApproveCancel.builder()
+                .approveId(approveId)
+                .cancelReason(detail.getCancelReason())
+                .build();
+
+        // 저장하기
+        approveCancelRepository.save(approveCancel);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/OvertimeFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/OvertimeFormStrategy.java
@@ -1,0 +1,36 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.OvertimeRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.work.command.domain.aggregate.Overtime;
+import com.dao.momentum.work.command.domain.repository.OvertimeRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OvertimeFormStrategy implements FormDetailStrategy {
+    private final ObjectMapper objectMapper;
+    private final OvertimeRepository overtimeRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // OvertimeRequest로 변환하기
+        OvertimeRequest detail = objectMapper.convertValue(
+                form, OvertimeRequest.class
+        );
+
+        // Overtime 만들기
+        Overtime overtime = Overtime.builder()
+                .approveId(approveId)
+                .startAt(detail.getStartAt())
+                .endAt(detail.getEndAt())
+                .breakTime(detail.getBreakTime())
+                .reason(detail.getReason())
+                .build();
+
+        // 저장하기
+        overtimeRepository.save(overtime);
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/ProposalFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/ProposalFormStrategy.java
@@ -1,0 +1,35 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.ApproveProposalRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.domain.aggregate.ApproveProposal;
+import com.dao.momentum.approve.command.domain.repository.ApproveProposalRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProposalFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final ApproveProposalRepository approveProposalRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // ApproveProposalRequest로 변환하기
+        ApproveProposalRequest detail = objectMapper.convertValue(
+                form, ApproveProposalRequest.class
+        );
+
+        // ApproveProposal 만들기
+        ApproveProposal approveProposal = ApproveProposal.builder()
+                .approveId(approveId)
+                .content(detail.getContent())
+                .build();
+
+        // 저장하기
+        approveProposalRepository.save(approveProposal);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/ReceiptFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/ReceiptFormStrategy.java
@@ -1,0 +1,39 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.ApproveReceiptRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.domain.aggregate.ApproveReceipt;
+import com.dao.momentum.approve.command.domain.repository.ApproveReceiptRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReceiptFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final ApproveReceiptRepository approveReceiptRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // ApproveReceiptRequest로 변환하기
+        ApproveReceiptRequest detail = objectMapper.convertValue(
+                form, ApproveReceiptRequest.class
+        );
+
+        // ApproveReceipt 만들기
+        ApproveReceipt approveReceipt = ApproveReceipt.builder()
+                .approveId(approveId)
+                .receiptType(detail.getReceiptType())
+                .storeName(detail.getStoreName())
+                .amount(detail.getAmount())
+                .storeAddress(detail.getAddress())
+                .usedAt(detail.getUsedAt())
+                .build();
+
+        // 저장하기
+        approveReceiptRepository.save(approveReceipt);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/RemoteWorkFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/RemoteWorkFormStrategy.java
@@ -1,0 +1,37 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.RemoteWorkRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.work.command.domain.aggregate.RemoteWork;
+import com.dao.momentum.work.command.domain.repository.RemoteWorkRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RemoteWorkFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final RemoteWorkRepository remoteWorkRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // RemoteWorkRequest 로 변환하기
+        RemoteWorkRequest detail = objectMapper.convertValue(
+                form, RemoteWorkRequest.class
+        );
+
+        // RemoteWork 만들기
+        RemoteWork remoteWork = RemoteWork.builder()
+                .approveId(approveId)
+                .startDate(detail.getStartDate())
+                .endDate(detail.getEndDate())
+                .reason(detail.getReason())
+                .build();
+
+        // 저장하기
+        remoteWorkRepository.save(remoteWork);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/VacationFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/VacationFormStrategy.java
@@ -1,0 +1,37 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.VacationRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.work.command.domain.aggregate.Vacation;
+import com.dao.momentum.work.command.domain.repository.VacationRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VacationFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final VacationRepository approveProposalRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // VacationRequest 로 변환하기
+        VacationRequest detail = objectMapper.convertValue(
+                form, VacationRequest.class
+        );
+
+        // Vacation 만들기
+        Vacation vacation = Vacation.builder()
+                .approveId(approveId)
+                .vacationTypeId(detail.getVacationTypeId())
+                .startDate(detail.getStartDate())
+                .endDate(detail.getEndDate())
+                .reason(detail.getReason())
+                .build();
+        // 저장하기
+        approveProposalRepository.save(vacation);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/WorkCorrectionFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/WorkCorrectionFormStrategy.java
@@ -1,0 +1,40 @@
+package com.dao.momentum.approve.command.application.service.strategy.form;
+
+import com.dao.momentum.approve.command.application.dto.request.approveType.WorkCorrectionRequest;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.work.command.domain.aggregate.WorkCorrection;
+import com.dao.momentum.work.command.domain.repository.WorkCorrectionRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WorkCorrectionFormStrategy implements FormDetailStrategy {
+
+    private final ObjectMapper objectMapper;
+    private final WorkCorrectionRepository workCorrectionRepository;
+
+    public void saveDetail(JsonNode form, Long approveId) {
+        // WorkCorrectionRequest로 변환하기
+        WorkCorrectionRequest detail = objectMapper.convertValue(
+                form, WorkCorrectionRequest.class
+        );
+
+        // WorkCorrection 만들기
+        WorkCorrection workCorrection = WorkCorrection.builder()
+                .approveId(approveId)
+                .workId(detail.getWorkId())
+                .beforeStartAt(detail.getBeforeStartAt())
+                .beforeEndAt(detail.getBeforeEndAt())
+                .afterStartAt(detail.getAfterStartAt())
+                .afterEndAt(detail.getAfterEndAt())
+                .reason(detail.getReason())
+                .build();
+
+        // 저장하기
+        workCorrectionRepository.save(workCorrection);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveCancelRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveCancelRepository.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveCancel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveCancelRepository extends JpaRepository<ApproveCancel, Long> {
+
+}
+

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveLineList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveLineListRepository extends JpaRepository<ApproveLineList, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveLine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveLineRepository extends JpaRepository<ApproveLine, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveProposalRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveProposalRepository.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveProposal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveProposalRepository extends JpaRepository<ApproveProposal, Long> {
+
+}
+

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveReceiptRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveReceiptRepository.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveReceipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveReceiptRepository extends JpaRepository<ApproveReceipt, Long> {
+
+}
+

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
@@ -1,0 +1,10 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.ApproveRef;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveRefRepository extends JpaRepository<ApproveRef, Long> {
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.approve.command.domain.repository;
+
+import com.dao.momentum.approve.command.domain.aggregate.Approve;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproveRepository extends JpaRepository<Approve, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/ApproveException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/ApproveException.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.approve.exception;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ApproveException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApproveException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/ReceiptApproveException.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/exception/ReceiptApproveException.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.approve.exception;
+
+import com.dao.momentum.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ReceiptApproveException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ReceiptApproveException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     INVALID_APPOINT_DATE("10013", "발령일은 오늘보다 빠를 수 없습니다." , HttpStatus.BAD_REQUEST),
     PASSWORD_NOT_CORRECT("10014", "유효하지 않은 비밀번호 변경입니다.", HttpStatus.BAD_REQUEST),
     EMAIL_SENDING_FAILED("10015", "이메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-
+    PARENT_APPROVE_ID_REQUIRED("30013", "취소 결재 요청 시 상위 결재 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
 
     // 회사 오류 (11001 - 11999)
     COMPANY_INFO_NOT_FOUND("11001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.common.exception;
 
+import com.dao.momentum.approve.exception.ApproveException;
 import com.dao.momentum.approve.exception.NotExistTabException;
 import com.dao.momentum.approve.exception.NotFoundApproveException;
 import com.dao.momentum.approve.exception.OcrRequestFailedException;
@@ -91,6 +92,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }
 
+    @ExceptionHandler(ApproveException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApproveException(ApproveException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
 
     @ExceptionHandler(EmailFailException.class)
     public ResponseEntity<ApiResponse<Void>> handleMailError(EmailFailException e) {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/BusinessTrip.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/BusinessTrip.java
@@ -3,11 +3,15 @@ package com.dao.momentum.work.command.domain.aggregate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "business_trip")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BusinessTrip {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,4 +36,19 @@ public class BusinessTrip {
     private String reason;
 
     private int cost;
+
+    @Builder
+    public BusinessTrip(
+            Long approveId, TypeEnum type, String place, LocalDate startDate,
+            LocalDate endDate, String reason, int cost
+    ){
+        this.approveId = approveId;
+        this.type = type;
+        this.place = place;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.reason = reason;
+        this.cost = cost;
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Overtime.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Overtime.java
@@ -3,11 +3,15 @@ package com.dao.momentum.work.command.domain.aggregate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "overtime")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Overtime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,10 +22,21 @@ public class Overtime {
     @NotNull
     private LocalDateTime startAt;
 
+    private int breakTime;
+
     @NotNull
     private LocalDateTime endAt;
 
     @NotBlank
     private String reason;
+
+    @Builder
+    public Overtime(Long approveId, LocalDateTime startAt, LocalDateTime endAt, int breakTime,String reason) {
+        this.approveId = approveId;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.breakTime = breakTime;
+        this.reason = reason;
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/RemoteWork.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/RemoteWork.java
@@ -2,11 +2,15 @@ package com.dao.momentum.work.command.domain.aggregate;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "remote_work")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RemoteWork {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,4 +26,11 @@ public class RemoteWork {
 
     private String reason;
 
+    @Builder
+    public RemoteWork(Long approveId, LocalDate startDate, LocalDate endDate, String reason) {
+        this.approveId = approveId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.reason = reason;
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Vacation.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Vacation.java
@@ -2,11 +2,15 @@ package com.dao.momentum.work.command.domain.aggregate;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "vacation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Vacation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +28,13 @@ public class Vacation {
 
     private String reason;
 
+    @Builder
+    public Vacation(int vacationTypeId, long approveId, LocalDate startDate,
+                    LocalDate endDate, String reason) {
+        this.vacationTypeId = vacationTypeId;
+        this.approveId = approveId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.reason = reason;
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkCorrection.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkCorrection.java
@@ -3,12 +3,17 @@ package com.dao.momentum.work.command.domain.aggregate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "work_correction")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WorkCorrection {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long workCorrectionId;
@@ -31,5 +36,19 @@ public class WorkCorrection {
 
     @NotBlank
     private String reason;
+
+    @Builder
+    public WorkCorrection(
+            Long workId, Long approveId, LocalDateTime beforeStartAt, LocalDateTime beforeEndAt,
+            LocalDateTime afterStartAt, LocalDateTime afterEndAt, String reason
+    ) {
+        this.workId = workId;
+        this.approveId = approveId;
+        this.beforeStartAt = beforeStartAt;
+        this.beforeEndAt = beforeEndAt;
+        this.afterStartAt = afterStartAt;
+        this.afterEndAt = afterEndAt;
+        this.reason = reason;
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.BusinessTrip;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BusinessTripRepository extends JpaRepository<BusinessTrip, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.Overtime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OvertimeRepository extends JpaRepository<Overtime, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.RemoteWork;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RemoteWorkRepository  extends JpaRepository<RemoteWork, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.Vacation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VacationRepository  extends JpaRepository<Vacation, Long> {
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
@@ -1,0 +1,9 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.WorkCorrection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WorkCorrectionRepository  extends JpaRepository<WorkCorrection, Long> {
+}


### PR DESCRIPTION
closes #9 

---

📌 개요
결재 문서 작성 기능 구현

🔨 주요 변경 사항
- `ApproveCommandController`
- `ApproveCommandService`, `ApproveCommandService` 
   - `createApproval` 결재선 생성 메서드 생성 
   - private 메서드로 결재선과 참조자 저장 메서드 생성
- `FormDetailStrategy`, `FormDetailStategyDispatcher`을 통해 결재 서류 별로 전략을 다르게 설정 
  - 각각의 결재 종류 별로 전략 객체 생성 (초과근무, 출장, 휴가, 재택 근무, 출퇴근 정정, 취소, 품의, 영수증)
- 각각의 결재 종류 별로 request 객체 생성 (초과근무, 출장, 휴가, 재택 근무, 출퇴근 정정, 취소, 품의, 영수증)
- 결재, 결재선, 참조자 requet 객체 생성
- 결재, 결재선, 참조자, 초과근무, 출장, 휴가, 재택 근무, 출퇴근 정정, 취소, 품의, 영수증 Repository 생성 
- 초과근무, 출장, 휴가, 재택 근무, 출퇴근 정정 엔티티에 빌터 패턴과 기본 생성자 어노테이션 추가
- 예외 처리
   - `GlobalExceptionHandler` 결재 예외 핸들러 추가 
   - `ErrorCode`에서 취소 결재 관련 에러 코드 추가 
 
✅ 리뷰 요청 사항
주요 로직 점검

⭐ 관련 이슈
#9 
