### PR TITLE
feat: 부서 삭제 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -121,7 +121,8 @@ public class SecurityConfig {
     private void masterEndpoints(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers("/position", "/position/**").hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.POST, "/departments").hasAuthority("MASTER")
-                .requestMatchers( HttpMethod.PUT, "/company","/departments").hasAuthority("MASTER");
+                .requestMatchers( HttpMethod.PUT, "/company","/departments").hasAuthority("MASTER")
+                .requestMatchers(HttpMethod.DELETE,"/departments/{deptId}").hasAuthority("MASTER");
     }
 
     // 인사관리자 전용

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     DEPARTMENT_NOT_FOUND("11002", "시스템 오류입니다." , HttpStatus.NOT_FOUND),
     INVALID_PARENT_DEPT("11003", "유효하지 않은 상위 부서입니다.", HttpStatus.BAD_REQUEST),
     INVALID_DEPT_HEAD("11004", "유효하지 않은 부서장입니다.", HttpStatus.BAD_REQUEST),
+    DEPARTMENT_NOT_EMPTY("11005","해당 부서에 사원이 남아있습니다.",HttpStatus.BAD_REQUEST),
+    DEPARTMENT_HAS_CHILD("11006","하위 부서가 존재합니다.",HttpStatus.BAD_REQUEST),
 
     // 계약서 오류 (12001 - 12999)
     INVALID_SALARY_AGREEMENT("12001", "연봉계약서에는 연봉이 작성되어야 합니다.", HttpStatus.BAD_REQUEST),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/application/controller/DepartmentCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/application/controller/DepartmentCommandController.java
@@ -4,21 +4,22 @@ import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.organization.department.command.application.dto.request.DepartmentCreateRequest;
 import com.dao.momentum.organization.department.command.application.dto.request.DepartmentUpdateRequest;
 import com.dao.momentum.organization.department.command.application.dto.response.DepartmentCreateResponse;
+import com.dao.momentum.organization.department.command.application.dto.response.DepartmentDeleteResponse;
 import com.dao.momentum.organization.department.command.application.dto.response.DepartmentUpdateResponse;
 import com.dao.momentum.organization.department.command.application.service.DepartmentCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.annotations.Delete;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/departments")
+@Tag(name = "부서", description = "부서 관련 Command API")
 public class DepartmentCommandController {
     private final DepartmentCommandService departmentCommandService;
 
@@ -38,6 +39,16 @@ public class DepartmentCommandController {
             @RequestBody @Valid DepartmentUpdateRequest request
     ){
         DepartmentUpdateResponse response = departmentCommandService.updateDepartment(request);
+
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
+    @Operation(summary="부서 삭제", description = "관리자는 회사의 부서를 삭제할 수 있다.")
+    @DeleteMapping("/{deptId}")
+    public ResponseEntity<ApiResponse<DepartmentDeleteResponse>> deleteDepartment(
+           @PathVariable Integer deptId
+    ){
+        DepartmentDeleteResponse response = departmentCommandService.deleteDepartment(deptId);
 
         return ResponseEntity.ok().body(ApiResponse.success(response));
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/application/dto/response/DepartmentDeleteResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/application/dto/response/DepartmentDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.dao.momentum.organization.department.command.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DepartmentDeleteResponse {
+    private Integer deptId;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/aggregate/Department.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/aggregate/Department.java
@@ -48,4 +48,9 @@ public class Department {
         this.name = request.getName();
         this.parentDeptId = request.getParentDeptId();
     }
+
+    public void delete(){
+        this.isDeleted = IsDeleted.Y;
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DepartmentRepository.java
@@ -2,7 +2,6 @@ package com.dao.momentum.organization.department.command.domain.repository;
 
 import com.dao.momentum.organization.department.command.domain.aggregate.Department;
 import com.dao.momentum.organization.department.command.domain.aggregate.IsDeleted;
-import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -16,4 +15,6 @@ public interface DepartmentRepository {
     Integer isSubDepartment(int parentDeptId,int childDeptId);
 
     boolean existsByDeptIdAndIsDeleted(Integer deptId, IsDeleted isDeleted);
+
+    boolean existsByParentDeptIdAndIsDeleted(Integer parentDeptId,IsDeleted isDeleted);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DeptHeadRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/domain/repository/DeptHeadRepository.java
@@ -1,7 +1,6 @@
 package com.dao.momentum.organization.department.command.domain.repository;
 
 import com.dao.momentum.organization.department.command.domain.aggregate.DeptHead;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/infrastructure/repository/JpaDepHeadRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/infrastructure/repository/JpaDepHeadRepository.java
@@ -1,8 +1,6 @@
 package com.dao.momentum.organization.department.command.infrastructure.repository;
 
-import com.dao.momentum.organization.department.command.domain.aggregate.Department;
 import com.dao.momentum.organization.department.command.domain.aggregate.DeptHead;
-import com.dao.momentum.organization.department.command.domain.repository.DepartmentRepository;
 import com.dao.momentum.organization.department.command.domain.repository.DeptHeadRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/infrastructure/repository/JpaDepartmentRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/department/command/infrastructure/repository/JpaDepartmentRepository.java
@@ -1,7 +1,6 @@
 package com.dao.momentum.organization.department.command.infrastructure.repository;
 
 import com.dao.momentum.organization.department.command.domain.aggregate.Department;
-import com.dao.momentum.organization.department.command.domain.aggregate.IsDeleted;
 import com.dao.momentum.organization.department.command.domain.repository.DepartmentRepository;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/repository/EmployeeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/repository/EmployeeRepository.java
@@ -22,4 +22,6 @@ public interface EmployeeRepository {
     boolean existsByEmpIdAndDeptId(Long empId, Integer DeptId);
 
     List<Employee> findAllByStatus(Status status);
+
+    boolean existsByDeptIdAndStatusIsNot(Integer deptId,Status status);
 }


### PR DESCRIPTION
closes #28 

---

📌 개요
- 부서 삭제 기능 구현
- 부서 삭제 시 소속 사원 및 하위 부서 여부 확인

🔨 주요 변경 사항
- DepartmentCommandController 및 DepartmentCommandService의 deleteDepartment 메소드 구현
- 엔드포인트 추가

✅ 리뷰 요청 사항
- 부서 삭제 기능 로직 확인

⭐ 관련 이슈
#28 
