### PR TITLE
feat : 결재 승인, 반려 기능 구현하기

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
@@ -1,7 +1,9 @@
 package com.dao.momentum.approve.command.application.controller;
 
+import com.dao.momentum.approve.command.application.dto.request.ApprovalConfirmRequest;
 import com.dao.momentum.approve.command.application.dto.request.ApproveRequest;
 import com.dao.momentum.approve.command.application.dto.response.ReceiptOcrResultResponse;
+import com.dao.momentum.approve.command.application.service.ApprovalDecisionCommandService;
 import com.dao.momentum.approve.command.application.service.ApproveCommandService;
 import com.dao.momentum.approve.command.application.service.OcrService;
 import com.dao.momentum.common.dto.ApiResponse;
@@ -23,6 +25,7 @@ public class ApproveCommandController {
 
     private final OcrService ocrService;
     private final ApproveCommandService approveCommandService;
+    private final ApprovalDecisionCommandService approvalDecisionCommandService;
 
     @PostMapping("/ocr/receipt")
     @Operation(summary = "영수증 내용 추출하기", description = "ocr api를 이용해 영수증 내용을 추출합니다.")
@@ -44,6 +47,20 @@ public class ApproveCommandController {
         Long empId = Long.parseLong(userDetails.getUsername());
 
         approveCommandService.createApproval(approveRequest, empId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/decision")
+    @Operation(summary = "결재 승인/반려 하기", description = "사원이 결재를 승인 또는 반려합니다.")
+    public ResponseEntity<ApiResponse<Void>> approveOrReject (
+            @RequestBody @Valid ApprovalConfirmRequest approvalConfirmRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        approvalDecisionCommandService.approveOrReject(approvalConfirmRequest, empId);
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApprovalConfirmRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApprovalConfirmRequest.java
@@ -1,0 +1,26 @@
+package com.dao.momentum.approve.command.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+@Schema(description = "결재 승인/반려 request")
+public class ApprovalConfirmRequest {
+
+    @NotNull(message = "결재선 목록 아이디(결재자)는 null일 수 없습니다.")
+    @Schema(description = "결재선 목록 ID", example = "1")
+    private final Long approveLineListId;
+
+    @NotNull(message = "승인/반려 여부는 반드시 선택해야 됩니다.")
+    @Schema(description = "승인/반려 여부", example = "승인")
+    private final String isApproved;
+
+    @Schema(description = "승인/반려 사유", example = "내용이 충분하지 않아 반려합니다.")
+    private final String reason;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalCancelCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalCancelCommandService.java
@@ -1,0 +1,116 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.domain.aggregate.Approve;
+import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.command.domain.aggregate.*;
+import com.dao.momentum.work.command.domain.repository.*;
+import com.dao.momentum.work.exception.WorkException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApprovalCancelCommandService {
+
+    private final WorkRepository workRepository;
+    private final WorkTypeRepository workTypeRepository;
+    private final BusinessTripRepository businessTripRepository;
+    private final OvertimeRepository overtimeRepository;
+    private final RemoteWorkRepository remoteWorkRepository;
+    private final VacationRepository vacationRepository;
+    private final WorkCorrectionRepository workCorrectionRepository;
+
+    @Transactional
+    public void cancelApprovalWork(Approve approve) {
+        ApproveType approveType = approve.getApproveType();
+        Long empId = approve.getEmpId();
+        Long approveId = approve.getApproveId();
+
+        switch (approveType) {
+            case OVERTIME -> {
+                Overtime overtime = overtimeRepository.findByApproveId(approveId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_OVERTIME));
+
+                LocalDate startDate = overtime.getStartAt().toLocalDate();
+                LocalDate endDate = overtime.getEndAt().toLocalDate();
+
+                deleteExistingWork(empId, startDate, endDate, WorkTypeName.OVERTIME);
+            }
+
+            case VACATION -> {
+                Vacation vacation = vacationRepository.findByApproveId(approveId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_VACATION));
+
+                LocalDate startDate = vacation.getStartDate();
+                LocalDate endDate = vacation.getEndDate();
+
+                deleteExistingWork(empId, startDate, endDate, WorkTypeName.VACATION);
+            }
+
+            case REMOTEWORK -> {
+                RemoteWork remote = remoteWorkRepository.findByApproveId(approveId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_REMOTE_WORK));
+
+                LocalDate startDate = remote.getStartDate();
+                LocalDate endDate = remote.getEndDate();
+
+                deleteExistingWork(empId, startDate, endDate, WorkTypeName.REMOTE_WORK);
+            }
+
+            case BUSINESSTRIP -> {
+                BusinessTrip businessTrip = businessTripRepository.findByApproveId(approveId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_BUSINESS_TRIP));
+
+                LocalDate startDate = businessTrip.getStartDate();
+                LocalDate endDate = businessTrip.getEndDate();
+
+                deleteExistingWork(empId, startDate, endDate, WorkTypeName.BUSINESS_TRIP);
+            }
+
+            case WORKCORRECTION -> {
+                WorkCorrection correction = workCorrectionRepository.findByApproveId(approveId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_WORK_CORRECTION));
+
+                long workId = correction.getWorkId();
+
+                Work work = workRepository.findById(workId)
+                        .orElseThrow(() -> new WorkException(ErrorCode.NOT_EXIST_WORK));
+
+                // 기존 출퇴근 시간으로 변경하기
+                work.changeBeforeWorkTime(correction.getBeforeStartAt(), correction.getBeforeEndAt());
+            }
+
+            case CANCEL -> {
+                // 이미 취소된 결재는 다시 취소할 수 없음
+                throw new ApproveException(ErrorCode.APPROVAL_ALREADY_CANCELED);
+            }
+        }
+    }
+
+    private void deleteExistingWork(long empId, LocalDate startDate, LocalDate endDate, WorkTypeName workTypeName) {
+        WorkType workType = getWorkType(workTypeName);
+
+        workRepository.deleteByEmployeeIdAndDateRangeAndWorkType(
+                empId,
+                startDate.atStartOfDay(),
+                endDate.plusDays(1).atStartOfDay(),
+                workType.getTypeId()
+        );
+    }
+
+    private WorkType getWorkType(WorkTypeName workTypeName) {
+        return workTypeRepository.findByTypeName(workTypeName)
+                .orElseThrow(() -> {
+                    log.error("WorkType '{}'을(를) 찾을 수 없음", workTypeName);
+                    return new WorkException(ErrorCode.WORKTYPE_NOT_FOUND);
+                });
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandService.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.application.dto.request.ApprovalConfirmRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ApprovalDecisionCommandService {
+    
+    void approveOrReject(ApprovalConfirmRequest approvalConfirmRequest, Long empId);
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
@@ -1,0 +1,226 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.application.dto.request.ApprovalConfirmRequest;
+import com.dao.momentum.approve.command.domain.aggregate.*;
+import com.dao.momentum.approve.command.domain.repository.ApproveLineListRepository;
+import com.dao.momentum.approve.command.domain.repository.ApproveLineRepository;
+import com.dao.momentum.approve.command.domain.repository.ApproveRepository;
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.work.command.application.service.WorkApplyCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ApprovalDecisionCommandServiceImpl implements ApprovalDecisionCommandService{
+
+    private final WorkApplyCommandService workApplyCommandService;
+    private final ApprovalCancelCommandService approvalCancelCommandService;
+    private final ApproveRepository approveRepository;
+    private final ApproveLineRepository approveLineRepository;
+    private final ApproveLineListRepository approveLineListRepository;
+
+    private static final int PENDING = 1;
+    private static final int APPROVED = 2;
+    private static final int REJECTED = 3;
+
+    private static final Set<ApproveType> WORK_APPROVE_TYPE = Set.of(
+            ApproveType.BUSINESSTRIP,
+            ApproveType.OVERTIME,
+            ApproveType.REMOTEWORK,
+            ApproveType.VACATION,
+            ApproveType.WORKCORRECTION
+    );
+
+    @Transactional
+    public void approveOrReject(ApprovalConfirmRequest approvalConfirmRequest, Long emdId){
+        Long approveLineListId = approvalConfirmRequest.getApproveLineListId();
+        String isApproved = approvalConfirmRequest.getIsApproved();
+        String reason = approvalConfirmRequest.getReason();
+
+        log.info("결재선 목록(결재자) : {}", approveLineListId);
+        log.info("승인/반려 여부 : {}", isApproved);
+        log.info("승인/반려 사유 : {}", reason);
+
+        // 1. 결재 관련 정보 가져오기
+        // 1-1. 결재선 목록(사람) 가져오기
+        ApproveLineList approvalAssignee = approveLineListRepository
+                .getApproveLineListById(approveLineListId)
+                .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_APPROVE_LINE_LIST));
+
+        Long approveLineId = approvalAssignee.getApproveLineId(); // 결재선 아이디
+        log.info("결재선 아이디 : {}", approveLineId);
+
+        // 접근할 수 없는 결재인 경우 (내가 결재선으로 지정된 결재가 아닌 경우)
+        if(!Objects.equals(approvalAssignee.getEmpId(), emdId)) {
+            log.info("접근할 수 없는 결재입니다.");
+            throw new ApproveException(ErrorCode.APPROVAL_ACCESS_DENIED);
+        }
+
+        // 1-2. 어떤 결재선인지 아이디 가져오기
+        ApproveLine approveLine = approveLineRepository
+                .getApproveLineById(approveLineId)
+                .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_APPROVE_LINE));
+
+        Long approveId = approveLine.getApproveId(); // 결재 아이디
+
+        log.info("결재 아이디 : {}", approveId);
+
+        // 대기 중인 상태가 아니라면 승인/반려 할 필요가 없음
+        if(approveLine.getStatusId() != PENDING) {
+            log.info("승인/반려된 결재선 입니다.");
+            throw new ApproveException(ErrorCode.APPROVAL_LINE_ALREADY_PROCESSED);
+        }
+
+        // 이전 결재선이 승인되지 않은 경우에는 예외 처리
+        List<ApproveLine> previousLines = approveLineRepository
+                .getApproveLinesBeforeOrder(approveId, approveLine.getApproveLineOrder());
+
+        // 이전 결재가 승인된 상태가 아니라면 결재를 진행할 수 없음
+        boolean hasPendingOrRejected = previousLines.stream()
+                .anyMatch(line -> line.getStatusId() != APPROVED);
+
+        if (hasPendingOrRejected) {
+            throw new ApproveException(ErrorCode.PREVIOUS_APPROVAL_NOT_COMPLETED);
+        }
+
+        // 1-3. 어떤 결재인지 아이디 가져오기
+        Approve approve = approveRepository
+                .getApproveByApproveId(approveId)
+                .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_APPROVE));
+
+        // 대기 중인 상태가 아니라면 승인/반려 할 필요가 없음
+        if(approve.getStatusId() != PENDING) {
+            log.info("승인/반려된 결재 입니다.");
+            throw new ApproveException(ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        }
+
+        // 2. 승인/반려 여부에 따라 각각 메서드 작성하기
+        if(isApproved.equals("승인")) { // 승인 결재인 경우
+            approve(approvalAssignee, approveLine, approve, reason);
+        } else { // 반려 결재인 경우
+            if(reason.isEmpty()) { // 결재 사유가 없는 경우 발생하는 에러
+                log.info("결재 반려 사유를 반드시 입력해야 합니다.");
+                throw new ApproveException(ErrorCode.MISSING_APPROVAL_REASON);
+            }
+            reject(approvalAssignee, approveLine, approve, reason);
+        }
+    }
+
+    /* 승인한 경우 */
+    private void approve(
+            ApproveLineList approvalAssignee,
+            ApproveLine approveLine,
+            Approve approve,
+            String reason
+
+    ) {
+        // 1. 결재선 목록 (결재자) 승인 상태로 변경
+        approvalAssignee.updateApproveLineListStatus(APPROVED);
+
+        // 2. 승인 사유가 있다면 승인 사유 넣기
+        if(!reason.isEmpty()) {
+            approvalAssignee.updateReason(reason);
+        }
+
+        // 3. 결재선의 필수/선택 여부에 따른 분류
+        updateApproveLineStatusIfCompleted(approveLine);
+
+        // 4. 만약에 승인된 결재선이 마지막 결재선이라면 결재를 승인으로 처리하기
+        updateApproveStatusIfFinalApprovalLine(approve);
+    }
+
+    /* 결재선 승인 여부 확인 */
+    private void updateApproveLineStatusIfCompleted(ApproveLine approveLine) {
+        // 선택 결재선은 한 명만 승인해도 승인 처리
+        if (approveLine.getIsRequiredAll() == IsRequiredAll.OPTIONAL) {
+            approveLine.updateApproveLineStatus(APPROVED);
+            notifyNextApproveLineIfExists(approveLine); // 다음 결재선이 있다면 알림
+        } else if (approveLine.getIsRequiredAll() == IsRequiredAll.REQUIRED) {
+            // 필수 결재선은 모두 승인해야 승인 처리 (결재선 아이디로 결재 목록 가져오기)
+            List<Integer> statusIds = approveLineListRepository
+                    .getAssigneeStatusByApproveLineId(approveLine.getId());
+
+            // 모든 결재자가 승인했는지 확인
+            boolean allApproved = statusIds.stream()
+                    .allMatch(statusId -> statusId == APPROVED);
+
+            if (allApproved) {
+                approveLine.updateApproveLineStatus(APPROVED);
+                notifyNextApproveLineIfExists(approveLine); // 다음 결재선이 있다면 알림
+            }
+        }
+    }
+
+    /* 다음 결재선 사람에게 알림*/
+    private void notifyNextApproveLineIfExists(ApproveLine currentLine) {
+        approveLineRepository.findNextLine(
+                currentLine.getApproveId(),
+                currentLine.getApproveLineOrder()       
+        ).ifPresent(nextLine -> {
+            // 다음 결재선에 속한 결재자 전부 조회 하기
+            List<ApproveLineList> assignees =
+                    approveLineListRepository.findByApproveLineId(nextLine.getId());
+
+            assignees.forEach(a -> {
+                /* 여기에서 알림 전송하면 됨 */
+                log.info("다음 결재선 사람에게 알림 보내기");
+            });
+        });
+    }
+
+    /* 마지막 결재선이 승인되었다면 결재를 승인으로 처리*/
+    private void updateApproveStatusIfFinalApprovalLine(Approve approve) {
+        List<Integer> approveLines = approveLineRepository.getApproveLinesByApproveId(approve.getApproveId());
+
+        boolean allApproved = approveLines.stream()
+                .allMatch(statusId -> statusId == APPROVED);
+
+        if (allApproved) {
+            approve.updateApproveStatus(APPROVED);
+
+            log.info("모든 결재선이 승인되어, 결재 {}이(가) 승인 처리됨", approve.getApproveId());
+
+            ApproveType approveType = approve.getApproveType();
+            if(WORK_APPROVE_TYPE.contains(approveType)) { // 근태 결재인 경우
+                workApplyCommandService.applyApprovalWork(approve);
+            } else if(approveType == ApproveType.CANCEL) { // 취소 결재인 경우
+                Long parentApproveId = approve.getParentApproveId();
+                
+                // 부모 결재 가져오기
+                Approve parentApprove = approveRepository
+                        .getApproveByApproveId(parentApproveId)
+                        .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_APPROVE));
+
+                // 결재 취소 시간 넣기
+                parentApprove.insertCancelDate();
+
+                approvalCancelCommandService.cancelApprovalWork(parentApprove);
+            }
+        }
+    }
+
+    /* 반려된 경우 작성되는 메소드 */
+    private void reject(
+            ApproveLineList approvalAssignee,
+            ApproveLine approveLine,
+            Approve approve,
+            String reason
+    ) {
+        // 결재자, 결재선, 결재내역 모두 상태를 반려 상태로 변경
+        approvalAssignee.updateApproveLineListStatus(REJECTED); // 결재 상태로 변경
+        approvalAssignee.updateReason(reason); // 반려 사유 설정
+
+        approveLine.updateApproveLineStatus(REJECTED);
+        approve.updateApproveStatus(REJECTED);
+    }
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
@@ -97,9 +97,11 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
             createApproveRef(approveId, approveRefRequests);
         }
 
+        notifyFirstApproveLine(approveId);
+
     }
 
-    // 결재선 생성하기 (결재선, 결재자 목록)
+    /* 결재선 생성하기 (결재선, 결재자 목록) */
     private void createApproveLine(Long approveId, List<ApproveLineRequest> approveLineRequests) {
         // 결재선은 여러 개 존재하기 때문에 반복문을 이용해 저장
         for (ApproveLineRequest lineRequest : approveLineRequests) {
@@ -126,7 +128,7 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
         }
     }
 
-    // 참조인 생성하기
+    /* 참조인 생성하기 */
     private void createApproveRef(Long approveId, List<ApproveRefRequest> approveRefRequests) {
         // 참조인은 여러명 이기 때문에 반복문을 이용해 저장
         for (ApproveRefRequest refRequest : approveRefRequests) {
@@ -138,6 +140,20 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
 
             approveRefRepository.save(approveRef);
         }
+    }
+
+    /* 첫번째 결재선(결재선 번호가 1) 사람에게 알림 보내기 */
+    private void notifyFirstApproveLine(Long approveId) {
+        approveLineRepository.findFirstLine(approveId)
+                .ifPresent(firstLine -> {
+
+                    List<ApproveLineList> assignees =
+                            approveLineListRepository.findByApproveLineId(firstLine.getId());
+
+                    assignees.forEach(a -> {
+                        // 알림 전송하기 (다음 결재선 사람들에게 알림 전송하기)
+                    });
+                });
     }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
@@ -60,5 +60,13 @@ public class Approve {
         this.cancelAt = cancelAt;
     }
 
+    public void updateApproveStatus(int statusId) {
+        this.statusId = statusId;
+        this.completeAt = LocalDateTime.now();
+    }
+
+    public void insertCancelDate() {
+        this.cancelAt = LocalDateTime.now();
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLine.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLine.java
@@ -44,4 +44,10 @@ public class ApproveLine {
         this.isRequiredAll = isRequiredAll;
         this.completeAt = completeAt;
     }
+
+    public void updateApproveLineStatus(int statusId) {
+        this.statusId = statusId;
+        this.completeAt = LocalDateTime.now();
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLineList.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveLineList.java
@@ -43,5 +43,17 @@ public class ApproveLineList {
         this.completeAt = completeAt;
         this.reason = reason;
     }
+
+    // 결재 상태를 업데이트
+    public void updateApproveLineListStatus(int statusId) {
+        this.statusId = statusId;
+    }
+
+    // 결재 상태를 업데이트
+    public void updateReason(String reason) {
+        this.reason = reason;
+        this.completeAt = LocalDateTime.now();
+    }
+    
 }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
@@ -2,8 +2,25 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveLineList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApproveLineListRepository extends JpaRepository<ApproveLineList, Long> {
+
+    /* 결재선 목록 아이디로 결재선 목록 가져오기 */
+    Optional<ApproveLineList> getApproveLineListById(Long approveLineListId);
+
+    /* 결재선 아이디로 결재선 목록의 상태 가져오기 */
+    @Query("SELECT all.statusId " +
+            "FROM ApproveLineList all " +
+            "WHERE all.approveLineId = :approveLineId")
+    List<Integer> getAssigneeStatusByApproveLineId(Long approveLineId);
+
+    /* 결재선 아이디로 해당 결재선의 결재자 목록 가져오기 */
+    List<ApproveLineList> findByApproveLineId(Long approveLineId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
@@ -2,8 +2,43 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveLine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApproveLineRepository extends JpaRepository<ApproveLine, Long> {
+
+    /* 결재선 아이디로 결재선을 가져오는 메소드*/
+    Optional<ApproveLine> getApproveLineById(Long approveLindId);
+
+    /* 결재 아이디로 해당 결재에 속한 결재선의 상태 가져오기 */
+    @Query("SELECT a.statusId FROM ApproveLine a WHERE a.approveId = :approveId")
+    List<Integer> getApproveLinesByApproveId(Long approveId);
+
+    /* 이전 결재선 찾기 */
+    @Query("SELECT a FROM ApproveLine a WHERE a.approveId = :approveId AND a.approveLineOrder < :currentOrder")
+    List<ApproveLine> getApproveLinesBeforeOrder(Long approveId, int currentOrder);
+
+    /* 다음 결재선 찾기 */
+    @Query("""
+       SELECT al
+       FROM ApproveLine al
+       WHERE al.approveId = :approveId
+         AND al.approveLineOrder > :currentOrder
+       ORDER BY al.approveLineOrder ASC
+       """)
+    Optional<ApproveLine> findNextLine(Long approveId, int currentOrder);
+
+    /* 결재 아이디로 해당 결재의 첫번째 결재선 찾기 */
+    @Query("""
+       SELECT al
+       FROM ApproveLine al
+       WHERE al.approveId = :approveId
+       ORDER BY al.approveLineOrder ASC
+       """)
+    Optional<ApproveLine> findFirstLine(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
@@ -4,6 +4,11 @@ import com.dao.momentum.approve.command.domain.aggregate.Approve;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ApproveRepository extends JpaRepository<Approve, Long> {
+
+    Optional<Approve> getApproveByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -24,7 +24,6 @@ public enum ErrorCode {
     INVALID_APPOINT_DATE("10013", "발령일은 오늘보다 빠를 수 없습니다." , HttpStatus.BAD_REQUEST),
     PASSWORD_NOT_CORRECT("10014", "유효하지 않은 비밀번호 변경입니다.", HttpStatus.BAD_REQUEST),
     EMAIL_SENDING_FAILED("10015", "이메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    PARENT_APPROVE_ID_REQUIRED("30013", "취소 결재 요청 시 상위 결재 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
 
     // 회사 오류 (11001 - 11999)
     COMPANY_INFO_NOT_FOUND("11001", "시스템 오류입니다.", HttpStatus.NOT_FOUND),
@@ -75,7 +74,15 @@ public enum ErrorCode {
     NOT_EXIST_CANCEL("30010", "존재하지 않는 취소 결재 상세 내역입니다.", HttpStatus.BAD_REQUEST),
     FAILED_OCR_CALL("30011", "OCR API 요청에 실패했습니다.", HttpStatus.BAD_REQUEST),
     RECEIPT_IMAGE_REQUIRED("30012", "영수증 결재에는 반드시 이미지 파일이 필요합니다.", HttpStatus.BAD_REQUEST),
-
+    PARENT_APPROVE_ID_REQUIRED("30013", "취소 결재 요청 시 상위 결재 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_APPROVE_LINE("30014", "존재하지 않는 결재선입니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_APPROVE_LINE_LIST("30015", "존재하지 않는 결재선 목록 입니다.", HttpStatus.BAD_REQUEST),
+    APPROVAL_ACCESS_DENIED("30016", "접근할 수 없는 결재입니다.", HttpStatus.FORBIDDEN),
+    MISSING_APPROVAL_REASON("30017", "반려 시 결재 사유는 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST),
+    APPROVAL_LINE_ALREADY_PROCESSED("30018", "이미 승인/반려 된 결재선입니다.", HttpStatus.BAD_REQUEST),
+    APPROVAL_ALREADY_PROCESSED("30019", "이미 승인/반려 된 결재입니다.", HttpStatus.BAD_REQUEST),
+    APPROVAL_ALREADY_CANCELED("30020", "이미 취소된 결재는 다시 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    PREVIOUS_APPROVAL_NOT_COMPLETED("30021", "이전 단계 결재가 완료 되지 않아 결재를 진행할 수 없습니다.", HttpStatus.BAD_REQUEST),
     // 평가 오류 (40001 ~ 49999)
     // KPI 오류
     STATISTICS_NOT_FOUND("40001", "해당 조건에 대한 KPI 통계가 없습니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/BusinessTrip.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/BusinessTrip.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "business_trip")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class BusinessTrip {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Overtime.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Overtime.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "overtime")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Overtime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/RemoteWork.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/RemoteWork.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "remote_work")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class RemoteWork {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Vacation.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Vacation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "vacation")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Vacation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/Work.java
@@ -62,6 +62,7 @@ public class Work {
         this.endAt = afterEndAt;
         this.breakTime = breakTime;
         this.vacationTypeId = vacationTypeId;
+        this.startPushedAt = null;
     }
 
     public Duration getWorkTime() {
@@ -73,4 +74,8 @@ public class Work {
         return this.getWorkTime().toMinutes() >= requiredMinutes;
     }
 
+    public void changeBeforeWorkTime(LocalDateTime startAt, LocalDateTime endAt) {
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkCorrection.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/aggregate/WorkCorrection.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "work_correction")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class WorkCorrection {
 
     @Id

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
@@ -1,9 +1,17 @@
 package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.BusinessTrip;
+import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BusinessTripRepository extends JpaRepository<BusinessTrip, Long> {
+
+    @Query(value = "SELECT * FROM business_trip WHERE approve_id = :approveId", nativeQuery = true)
+    Optional<BusinessTrip> findByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
@@ -2,8 +2,15 @@ package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface OvertimeRepository extends JpaRepository<Overtime, Long> {
+
+    @Query(value = "SELECT * FROM overtime WHERE approve_id = :approveId", nativeQuery = true)
+    Optional<Overtime> findByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
@@ -1,9 +1,17 @@
 package com.dao.momentum.work.command.domain.repository;
 
+import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import com.dao.momentum.work.command.domain.aggregate.RemoteWork;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface RemoteWorkRepository  extends JpaRepository<RemoteWork, Long> {
+
+    @Query(value = "SELECT * FROM remote_work WHERE approve_id = :approveId", nativeQuery = true)
+    Optional<RemoteWork> findByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
@@ -2,8 +2,15 @@ package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Vacation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface VacationRepository  extends JpaRepository<Vacation, Long> {
+
+    @Query(value = "SELECT * FROM vacation WHERE approve_id = :approveId", nativeQuery = true)
+    Optional<Vacation> findByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationTypeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationTypeRepository.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.work.command.domain.repository;
+
+import com.dao.momentum.work.command.domain.aggregate.VacationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VacationTypeRepository extends JpaRepository<VacationType, Integer> {
+
+    VacationType getVacationTypeByVacationTypeId(int vacationTypeId);
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
@@ -1,9 +1,17 @@
 package com.dao.momentum.work.command.domain.repository;
 
+import com.dao.momentum.work.command.domain.aggregate.Vacation;
 import com.dao.momentum.work.command.domain.aggregate.WorkCorrection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface WorkCorrectionRepository  extends JpaRepository<WorkCorrection, Long> {
+
+    @Query(value = "SELECT * FROM work_correction WHERE approve_id = :approveId", nativeQuery = true)
+    Optional<WorkCorrection> findByApproveId(Long approveId);
+
 }


### PR DESCRIPTION
closes #10 

---

📌 개요
결재 승인, 반려 기능 구현하기

🔨 주요 변경 사항
- `ApproveCommandController`
   - `/approval/descision` 경로로 승인, 반려 요청 받기
   - `ApproveConfirmRequest` 생성하기 (승인, 반려 요청 객체) 
- `ApproveCommandService`, `ApproveCommandServiceImpl`
   - `ApproveCancelService` : 취소 결재 관련된 서비스 로직 (근태 내역 변경)
   - `WorkApplyService` : 결재 승인 시 근태 관련된 변경을 작성한 서비스 
- `ErrorCode` 에서 결재 관련 에러 코드 생성
- 엔티티 관련된 수정
  - `Approve`, `ApproveLine`, `ApproveLineList`  각각의 엔티티에 수정 관련 메소드 추가하기 
  - 근태 관련(BusinessTrip, Overtime, RemoteWork, Vacation, WorkCorrection` 엔티티에 Getter 어노테이션 추가 
- `ApproveRespository`, `ApproveLineRespository`, `ApproveLineListRespository`

✅ 리뷰 요청 사항
로직 점검

⭐ 관련 이슈
#10 
