### PR TITLE
feat: 특정 사원 권한 조회 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -125,7 +125,8 @@ public class SecurityConfig {
     private void masterEndpoints(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
                 "/position", "/position/**",
-                "/employees/roles"
+                "/employees/roles",
+                "/employees/{empId}/roles"
                 ).hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.POST, "/departments","/holiday").hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.PUT, "/company","/departments").hasAuthority("MASTER")

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/controller/AdminEmployeeQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/controller/AdminEmployeeQueryController.java
@@ -3,10 +3,7 @@ package com.dao.momentum.organization.employee.query.controller;
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.organization.employee.query.dto.request.AppointSearchRequest;
 import com.dao.momentum.organization.employee.query.dto.request.EmployeeSearchRequest;
-import com.dao.momentum.organization.employee.query.dto.response.AppointListResponse;
-import com.dao.momentum.organization.employee.query.dto.response.EmployeeDetailsResponse;
-import com.dao.momentum.organization.employee.query.dto.response.EmployeeListResponse;
-import com.dao.momentum.organization.employee.query.dto.response.UserRolesResponse;
+import com.dao.momentum.organization.employee.query.dto.response.*;
 import com.dao.momentum.organization.employee.query.service.EmployeeQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -65,6 +62,16 @@ public class AdminEmployeeQueryController {
     public ResponseEntity<ApiResponse<UserRolesResponse>> getRoles(
     ) {
         UserRolesResponse response = employeeQueryService.getUserRoles();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{empId}/roles")
+    @Operation(summary = "사원 권한 목록 조회", description = "관리자가 특정 사원의 서비스 권한 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<EmployeeRolesResponse>> getEmployeeRoles(
+            @PathVariable long empId
+    ) {
+        EmployeeRolesResponse response = employeeQueryService.getEmployeeRoles(empId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/response/EmployeeRoleDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/response/EmployeeRoleDTO.java
@@ -1,0 +1,10 @@
+package com.dao.momentum.organization.employee.query.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmployeeRoleDTO {
+    private int userRoleId;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/response/EmployeeRolesResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/response/EmployeeRolesResponse.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.organization.employee.query.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class EmployeeRolesResponse {
+    private List<Integer> userRolesIds;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/mapper/UserRoleMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/mapper/UserRoleMapper.java
@@ -1,7 +1,9 @@
 package com.dao.momentum.organization.employee.query.mapper;
 
+import com.dao.momentum.organization.employee.query.dto.response.EmployeeRoleDTO;
 import com.dao.momentum.organization.employee.query.dto.response.UserRoleDTO;
 import org.apache.ibatis.annotations.Mapper;
+
 import java.util.List;
 
 @Mapper
@@ -9,4 +11,6 @@ public interface UserRoleMapper {
     List<String> findByEmpId (long empId);
 
     List<UserRoleDTO> getUserRoles();
+
+    List<EmployeeRoleDTO> getEmployeeRoles(long empId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/service/EmployeeQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/service/EmployeeQueryService.java
@@ -86,4 +86,16 @@ public class EmployeeQueryService {
                 .userRoles(userRoles)
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public EmployeeRolesResponse getEmployeeRoles(long empId) {
+        List<EmployeeRoleDTO> employeeRoles = userRoleMapper.getEmployeeRoles(empId);
+
+        List<Integer> userRolesIds = employeeRoles.stream()
+                .map(EmployeeRoleDTO::getUserRoleId).toList();
+
+        return EmployeeRolesResponse.builder()
+                .userRolesIds(userRolesIds)
+                .build();
+    }
 }

--- a/momentum-dao-be/src/main/resources/mappers/organization/UserRoleMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/organization/UserRoleMapper.xml
@@ -19,4 +19,12 @@
         ORDER BY user_role_id ASC
     </select>
 
+    <select id="getEmployeeRoles" resultType="com.dao.momentum.organization.employee.query.dto.response.EmployeeRoleDTO">
+        SELECT
+            user_role_id
+        FROM employee_roles
+        WHERE emp_id = #{empId}
+        ORDER BY user_role_id ASC
+    </select>
+
 </mapper>


### PR DESCRIPTION
closes #256

---

📌 개요
- 특정 사원 권한 조회 기능 구현

🔨 주요 변경 사항
- 컨트롤러, 서비스, mapper 메서드, xml 쿼리, dto 작성
- SecurityConfig 수정

✅ 리뷰 요청 사항
- 응답 객체 적절한지

PS) empId의 존재 여부는 따로 검증하지 않고 있음.
MyBatis 쪽의 list 조회 형태여서 "존재하지 않는 사원"과 "아무런 권한이 없는 사원"이 구분되지 않는 상태
필요 시 관련 로직 추가

⭐ 관련 이슈
#256 
