### PR TITLE
feat: 휴일 조회 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -127,6 +127,7 @@ public class SecurityConfig {
                 "/position", "/position/**",
                 "/employees/roles"
                 ).hasAuthority("MASTER")
+                .requestMatchers(HttpMethod.GET,"/holiday").hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.POST, "/departments","/holiday").hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.PUT, "/company","/departments").hasAuthority("MASTER")
                 .requestMatchers(HttpMethod.DELETE,"/departments/{deptId}").hasAuthority("MASTER");

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/controller/HolidayQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/controller/HolidayQueryController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class HolidayQueryController {
     private final HolidayQueryService holidayQueryService;
 
-    @Operation(summary="회사 휴일 조회", description = "사원은 회사의 휴일을 조회할 수 있다.")
+    @Operation(summary="회사 휴일 조회", description = "관리자는 회사의 휴일을 조회할 수 있다.")
     @GetMapping
     public ResponseEntity<ApiResponse<HolidayGetResponse>> getHolidays(
             @RequestBody HolidaySearchRequest request

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/controller/HolidayQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/controller/HolidayQueryController.java
@@ -1,0 +1,32 @@
+package com.dao.momentum.organization.company.query.controller;
+
+import com.dao.momentum.common.dto.ApiResponse;
+import com.dao.momentum.organization.company.query.dto.request.HolidaySearchRequest;
+import com.dao.momentum.organization.company.query.dto.response.HolidayGetResponse;
+import com.dao.momentum.organization.company.query.service.HolidayQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/holiday")
+@Tag(name = "휴일", description = "휴일 관련 Query API")
+public class HolidayQueryController {
+    private final HolidayQueryService holidayQueryService;
+
+    @Operation(summary="회사 휴일 조회", description = "사원은 회사의 휴일을 조회할 수 있다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<HolidayGetResponse>> getHolidays(
+            @RequestBody HolidaySearchRequest request
+            ) {
+        HolidayGetResponse response = holidayQueryService.getHolidays(request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/request/HolidaySearchDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/request/HolidaySearchDTO.java
@@ -1,0 +1,35 @@
+package com.dao.momentum.organization.company.query.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HolidaySearchDTO {
+    private Integer year;
+    private Integer month;
+    private Integer page;
+    private Integer size;
+
+    public static HolidaySearchDTO from(HolidaySearchRequest request){
+        return HolidaySearchDTO.builder()
+                .year(request.getYear())
+                .month(request.getMonth())
+                .page(request.getPage())
+                .size(request.getSize())
+                .build();
+    }
+
+    public int getPage() {
+        return page != null ? page : 1;
+    }
+
+    public int getSize() {
+        return size != null ? size : 10;
+    }
+
+    public int getOffset() {
+        return (getPage() - 1) * getSize();
+    }
+}
+

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/request/HolidaySearchRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/request/HolidaySearchRequest.java
@@ -1,0 +1,16 @@
+package com.dao.momentum.organization.company.query.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HolidaySearchRequest {
+    private Integer year;
+
+    private Integer month;
+
+    private Integer page=1;
+
+    private Integer size=10;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/response/HolidayGetDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/response/HolidayGetDTO.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.organization.company.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class HolidayGetDTO {
+    private Integer holidayId;
+    private String holidayName;
+    private LocalDate date;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/response/HolidayGetResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/dto/response/HolidayGetResponse.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.organization.company.query.dto.response;
+
+import com.dao.momentum.common.dto.Pagination;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class HolidayGetResponse {
+    private List<HolidayGetDTO> holidayGetDTOList;
+    private Pagination pagination;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/mapper/HolidayMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/mapper/HolidayMapper.java
@@ -1,0 +1,14 @@
+package com.dao.momentum.organization.company.query.mapper;
+
+import com.dao.momentum.organization.company.query.dto.request.HolidaySearchDTO;
+import com.dao.momentum.organization.company.query.dto.request.HolidaySearchRequest;
+import com.dao.momentum.organization.company.query.dto.response.HolidayGetDTO;
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface HolidayMapper {
+    List<HolidayGetDTO> searchHolidays(HolidaySearchDTO dto);
+
+    long countHolidays(HolidaySearchRequest request);
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/service/HolidayQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/company/query/service/HolidayQueryService.java
@@ -1,0 +1,39 @@
+package com.dao.momentum.organization.company.query.service;
+
+import com.dao.momentum.common.dto.Pagination;
+import com.dao.momentum.organization.company.query.dto.request.HolidaySearchDTO;
+import com.dao.momentum.organization.company.query.dto.request.HolidaySearchRequest;
+import com.dao.momentum.organization.company.query.dto.response.HolidayGetDTO;
+import com.dao.momentum.organization.company.query.dto.response.HolidayGetResponse;
+import com.dao.momentum.organization.company.query.mapper.HolidayMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class HolidayQueryService {
+    private final HolidayMapper holidayMapper;
+    public HolidayGetResponse getHolidays(HolidaySearchRequest request) {
+        HolidaySearchDTO holidaySearchDTO = HolidaySearchDTO.from(request);
+
+        List<HolidayGetDTO> holidayGetDTOList = holidayMapper.searchHolidays(holidaySearchDTO);
+
+        long totalItems = holidayMapper.countHolidays(request);
+
+        int totalPage = (int) Math.ceil((double) totalItems / holidaySearchDTO.getSize());
+
+        Pagination pagination = Pagination.builder()
+                .currentPage(holidaySearchDTO.getPage())
+                .totalPage(totalPage)
+                .totalItems(totalItems)
+                .build();
+
+        return HolidayGetResponse.builder()
+                .holidayGetDTOList(holidayGetDTOList)
+                .pagination(pagination)
+                .build();
+    }
+}

--- a/momentum-dao-be/src/main/resources/mappers/organization/HolidayMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/organization/HolidayMapper.xml
@@ -1,0 +1,34 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.organization.company.query.mapper.HolidayMapper">
+    <select id="searchHolidays" resultType="com.dao.momentum.organization.company.query.dto.response.HolidayGetDTO">
+        SELECT
+                holiday_id,
+                holiday_name,
+                date
+        FROM holiday
+        WHERE 1 = 1
+        <if test="year != null">
+            AND YEAR(date) = #{year}
+        </if>
+        <if test="month != null">
+            AND MONTH(date) = #{month}
+        </if>
+        ORDER BY date
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 전체 개수 조회 -->
+    <select id="countHolidays" resultType="long">
+        SELECT COUNT(*)
+        FROM holiday
+        WHERE 1=1
+        <if test="year != null">
+            AND YEAR(date) = #{year}
+        </if>
+        <if test="month != null">
+            AND MONTH(date) = #{month}
+        </if>
+    </select>
+</mapper>


### PR DESCRIPTION
closes #262 

---

📌 개요
- 휴일 조회 기능 구현
- 관리자는 회사의 휴일들을 검색조건을 걸어서 조회할 수 있다.

🔨 주요 변경 사항
- HolidayQueryService.getHolidays 메소드 구현
- HolidayQueryController.getHolidays 메소드 구현

✅ 리뷰 요청 사항
- 휴일 조회 기능 로직 확인 
- 커밋 메세지는 잘못 적었습니다.

⭐ 관련 이슈
#262 
