### PR TITLE
refactor : 결재 문서 작성 요청, 응답 객체에 description  추가

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineListRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,12 +9,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "결재자 지정 request")
 public class ApproveLineListRequest {
 
     @NotNull(message = "상태 아이디는 null일 수 없습니다.")
+    @Schema(description = "결재선 목록 상태(대기, 승인, 반려) 아이디", example = "1")
     private final Integer statusId;
 
     @NotNull(message = "사원 아이디는 null일 수 없습니다.")
+    @Schema(description = "결재선에 지정된 사원 ID", example = "1")
     private final Long empId;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveLineRequest.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.command.application.dto.request;
 
 import com.dao.momentum.approve.command.domain.aggregate.IsRequiredAll;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,15 +12,20 @@ import java.util.List;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "결재선 request")
 public class ApproveLineRequest {
 
     @NotNull(message = "상태 아이디는 null일 수 없습니다.")
+    @Schema(description = "결재선 상태(대기, 승인, 반려) 아이디", example = "1")
     private final Integer statusId;
 
     @NotNull(message = "결재선 순서는 null일 수 없습니다.")
+    @Schema(description = "결재선 순서", example = "1")
     private final Integer approveLineOrder;
 
+    @Schema(description = "결재선 필수/선택 여부")
     private final IsRequiredAll isRequiredAll;
 
+    @Schema(description = "결재선에 지정된 결재자 목록")
     private final List<ApproveLineListRequest> approveLineList;
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRefRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRefRequest.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.command.application.dto.request;
 
 import com.dao.momentum.approve.command.domain.aggregate.IsConfirmed;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -10,12 +11,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "참조자 request")
 public class ApproveRefRequest {
 
     @NotBlank(message = "사원 id는 null일 수 없습니다.")
+    @Schema(description = "참조 사원 ID", example = "1")
     private final Long empId;
 
     @NotNull
+    @Schema(description = "참조 여부")
     private final IsConfirmed isConfirmed;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/ApproveRequest.java
@@ -3,6 +3,7 @@ package com.dao.momentum.approve.command.application.dto.request;
 import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.file.command.application.dto.request.AttachmentRequest;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,26 +16,34 @@ import java.util.List;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "결재 request")
 public class ApproveRequest {
 
+    @Schema(description = "상위 결재 ID", example = "1")
     private final Long parentApproveId;
 
     @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+    @Schema(description = "결재 제목")
     private final String approveTitle;
 
     @NotNull
+    @Schema(description = "결재 종류")
     private final ApproveType approveType;
 
     // 결재선
+    @Schema(description = "결재선 목록")
     private final List<ApproveLineRequest> approveLineLists;
 
     // 참조하는 사람
+    @Schema(description = "참조 사원 목록")
     private final List<ApproveRefRequest> refRequests;
 
     // 결재 문서가 많아서 이것을 DTO로 통합하기 어려움
     // 그래서 json 형식으로 폼을 저장한 뒤에 나중에 DTO 객체로 변환해서 사용함
+    @Schema(description = "결재 문서 내용")
     private final JsonNode formDetail;
 
     @Valid
+    @Schema(description = "첨부파일 목록")
     private final List<AttachmentRequest> attachments; // S3에 미리 업로드된 파일 정보 전달
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveCancelRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveCancelRequest.java
@@ -1,14 +1,17 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "취소 결재 request")
 public class ApproveCancelRequest {
 
     @NotBlank(message="취소 사유는 반드시 입력해야 합니다.")
+    @Schema(description = "취소 사유")
     private final String cancelReason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveProposalRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveProposalRequest.java
@@ -1,14 +1,17 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "품의 결재 request")
 public class ApproveProposalRequest {
 
     @NotBlank(message="품의 내용은 반드시 입력해야 합니다.")
+    @Schema(description = "품의 결재 내용")
     private final String content;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveReceiptRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/ApproveReceiptRequest.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
 import com.dao.momentum.approve.command.domain.aggregate.ReceiptType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -12,20 +13,26 @@ import java.time.LocalDate;
 @Builder
 @Getter
 @RequiredArgsConstructor
+@Schema(description = "영수증 결재 request")
 public class ApproveReceiptRequest {
 
     @NotNull(message="영수증 종류는 반드시 선택해야 합니다.")
+    @Schema(description = "영수증 종류")
     private final ReceiptType receiptType;
 
     @NotBlank(message = "가게 이름은 반드시 작성해야 합니다.")
+    @Schema(description = "가게 이름")
     private final String storeName;
 
+    @Schema(description = "총 금액")
     private final int amount;
 
     @NotBlank(message="가게 주소는 반드시 작성해야 합니다.")
+    @Schema(description = "가게 주소")
     private final String address;
 
     @NotNull(message="사용한 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "사용 날짜")
     private final LocalDate usedAt;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/BusinessTripRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/BusinessTripRequest.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
 import com.dao.momentum.work.command.domain.aggregate.TypeEnum;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -10,23 +11,30 @@ import java.time.LocalDate;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "출장 결재 request")
 public class BusinessTripRequest {
 
     @NotNull(message="출장 종류는 반드시 선택해야 합니다.")
+    @Schema(description = "출장 종류")
     private final TypeEnum type;
 
     @NotBlank(message="출장 장소는 반드시 작성해야 합니다.")
+    @Schema(description = "출장 장소")
     private final String place;
 
     @NotNull(message="출장 시작 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "출장 시작 날짜")
     private final LocalDate startDate;
 
     @NotNull(message="출장 종료 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "출장 종료 날짜")
     private final LocalDate endDate;
 
     @NotNull(message="출장 사유는 반드시 작성해야 합니다.")
+    @Schema(description = "출장 사유")
     private final String reason;
 
+    @Schema(description = "출장 비용")
     private final int cost;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/OvertimeRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -8,17 +9,22 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "초과 근무 결재 request")
 public class OvertimeRequest {
 
     @NotNull(message="초과 근무 시작 시간은 반드시 작성해야 합니다.")
+    @Schema(description = "초과 근무 시작 시간")
     private final LocalDateTime startAt;
 
     @NotNull(message="초과 근무 종료 시간은 반드시 작성해야 합니다.")
+    @Schema(description = "초과 근무 종료 시간")
     private final LocalDateTime endAt;
 
+    @Schema(description = "쉬는 시간")
     private final int breakTime;
 
     @NotNull(message="초과 근무 사유는 반드시 작성해야 합니다.")
+    @Schema(description = "초과 근무 사유")
     private final String reason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/RemoteWorkRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/RemoteWorkRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -8,14 +9,18 @@ import java.time.LocalDate;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "재택 근무 결재 request")
 public class RemoteWorkRequest {
 
     @NotNull(message="재택 근무 시작 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "재택 근무 시작 날짜")
     private final LocalDate startDate;
 
     @NotNull(message="재택 근무 종료 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "재택 근무 종료 날짜")
     private final LocalDate endDate;
 
+    @Schema(description = "재택 근무 사유")
     private final String reason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/VacationRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/VacationRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -8,16 +9,21 @@ import java.time.LocalDate;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "휴가 결재 request")
 public class VacationRequest {
 
+    @Schema(description = "휴가 타입", example = "1")
     private final int vacationTypeId;
 
     @NotNull(message="휴가 시작 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "휴가 시작 날짜")
     private final LocalDate startDate;
 
     @NotNull(message="휴가 종료 날짜는 반드시 작성해야 합니다.")
+    @Schema(description = "휴가 종료 날짜")
     private final LocalDate endDate;
 
+    @Schema(description = "휴가 사유")
     private final String reason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/request/approveType/WorkCorrectionRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.request.approveType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -8,24 +9,31 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "출퇴근 정정 결재 request")
 public class WorkCorrectionRequest {
 
     @NotNull(message="정정하고자 하는 근무 번호는 반드시 선택해야 합니다.")
+    @Schema(description = "정정 근무 ID", example = "1")
     private final Long workId;
 
     @NotNull(message="기존 출근 일시는 반드시 작성해야 합니다.")
+    @Schema(description = "기존 출근 일시")
     private final LocalDateTime beforeStartAt;
 
     @NotNull(message="기존 퇴근 일시는 반드시 작성해야 합니다.")
+    @Schema(description = "기존 퇴근 일시")
     private final LocalDateTime beforeEndAt;
 
     @NotNull(message="수정 출근 일시는 반드시 작성해야 합니다.")
+    @Schema(description = "수정 출근 일시")
     private final LocalDateTime afterStartAt;
 
     @NotNull(message="수정 퇴근 일시는 반드시 작성해야 합니다.")
+    @Schema(description = "수정 퇴근 일시")
     private final LocalDateTime afterEndAt;
 
     @NotNull(message="출퇴근 정정 사유는 반드시 작성해야 합니다.")
+    @Schema(description = "출퇴근 정정 사유")
     private final String reason;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/response/ReceiptOcrResultResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/dto/response/ReceiptOcrResultResponse.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.command.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,11 +8,19 @@ import java.time.LocalDate;
 
 @Builder
 @Getter
+@Schema(description = "영수증 OCR API 사용 response")
 public class ReceiptOcrResultResponse {
-
+    
+    @Schema(description = "가게 이름")
     private String storeName;
+
+    @Schema(description = "총 금액")
     private Integer amount;
+
+    @Schema(description = "가게 주소")
     private String address;
+
+    @Schema(description = "사용 날짜")
     private LocalDate usedAt;
 
 }


### PR DESCRIPTION
closes #9

---

📌 개요
결재 문서 작성 요청, 응답 객체에 description  추가

🔨 주요 변경 사항
- request 객체에 스웨거에서 사용되는 description  추가
  - `ApproveLineListRequest`
  - `ApproveLineRequest`
  - `ApproveRefRequest`
  - `ApproveRequest`
  - `ApproveCancelRequest`
  - `ApproveProposalRequest`
  - `ApproveReceiptRequest`
  - `BusinessTripRequest`
  - `OvertimeRequest`
  - `RemoteWorkRequest`
  - `VacationRequest`
  - `WorkCorrectionRequest`
 
- response 객체에 스웨거에서 사용되는 description  추가
  - `ReceiptOcrResultResponse` 

✅ 리뷰 요청 사항

⭐ 관련 이슈
#9
