### PR TITLE
feat : 참조 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
@@ -65,5 +65,17 @@ public class ApproveCommandController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @PatchMapping("/documents/{documentId}/reference")
+    @Operation(summary = "결재 참조 열람", description = "결재 참조자가 결재 내역을 열람합니다.")
+    public ResponseEntity<ApiResponse<Void>> viewAsReference(
+            @PathVariable Long documentId ,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        approveCommandService.viewAsReference(documentId, empId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandService.java
@@ -8,4 +8,5 @@ public interface ApprovalDecisionCommandService {
     
     void approveOrReject(ApprovalConfirmRequest approvalConfirmRequest, Long empId);
 
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
@@ -8,4 +8,6 @@ public interface ApproveCommandService {
 
     void createApproval(ApproveRequest approveRequest, Long empId);
 
+    void viewAsReference(Long approveId, Long empId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
@@ -31,6 +31,9 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
     private final ApproveRefRepository approveRefRepository;
     private final FileRepository fileRepository;
 
+    /*
+    * 결재 문서를 작성하는 메소드
+    * */
     @Transactional
     public void createApproval(ApproveRequest approveRequest, Long empId) {
         // ApproveRequest 에 들어 있는 값 가져오기
@@ -101,7 +104,24 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
 
     }
 
-    /* 결재선 생성하기 (결재선, 결재자 목록) */
+    /*
+     * 참조인이 결재 내역을 확인하는 메소드
+     * */
+    @Transactional
+    public void viewAsReference(Long approveId, Long empId) {
+        // 1. 결재 아이디와 참조 사원 Id로 결재 참조 내역 불러오기
+       ApproveRef approveRef = approveRefRepository.getApproveRefByApproveIdAndEmpId(approveId, empId)
+               .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_REF));
+
+       log.info("해당 참조의 결재 아이디 : {},  해당 참조의 사원 아이디 : {}", approveId, empId);
+
+        // 2. 참조 테이블 참조 상태 변경하기
+        approveRef.updateRefStatus();
+    }
+
+    /*
+     * 결재선 생성하기 (결재선, 결재자 목록)
+     * */
     private void createApproveLine(Long approveId, List<ApproveLineRequest> approveLineRequests) {
         // 결재선은 여러 개 존재하기 때문에 반복문을 이용해 저장
         for (ApproveLineRequest lineRequest : approveLineRequests) {
@@ -128,7 +148,9 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
         }
     }
 
-    /* 참조인 생성하기 */
+    /*
+    * 참조인 생성하기
+    * */
     private void createApproveRef(Long approveId, List<ApproveRefRequest> approveRefRequests) {
         // 참조인은 여러명 이기 때문에 반복문을 이용해 저장
         for (ApproveRefRequest refRequest : approveRefRequests) {
@@ -142,7 +164,9 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
         }
     }
 
-    /* 첫번째 결재선(결재선 번호가 1) 사람에게 알림 보내기 */
+    /*
+     * 첫번째 결재선(결재선 번호가 1) 사람에게 알림 보내기
+     * */
     private void notifyFirstApproveLine(Long approveId) {
         approveLineRepository.findFirstLine(approveId)
                 .ifPresent(firstLine -> {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveRef.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/ApproveRef.java
@@ -33,4 +33,9 @@ public class ApproveRef {
         this.empId = empId;
         this.isConfirmed = isConfirmed;
     }
+
+    /* 참조 상태를 '확인'으로 변경하는 메소드 */
+    public void updateRefStatus() {
+        isConfirmed = IsConfirmed.Y;
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
@@ -4,7 +4,11 @@ import com.dao.momentum.approve.command.domain.aggregate.ApproveRef;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ApproveRefRepository extends JpaRepository<ApproveRef, Long> {
+
+    Optional<ApproveRef> getApproveRefByApproveIdAndEmpId(Long approveId, Long empId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -88,6 +88,8 @@ public enum ErrorCode {
     APPROVAL_ALREADY_PROCESSED("30019", "이미 승인/반려 된 결재입니다.", HttpStatus.BAD_REQUEST),
     APPROVAL_ALREADY_CANCELED("30020", "이미 취소된 결재는 다시 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
     PREVIOUS_APPROVAL_NOT_COMPLETED("30021", "이전 단계 결재가 완료 되지 않아 결재를 진행할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_REF("30022", "존재하지 않는 참조 내역입니다.", HttpStatus.BAD_REQUEST),
+
     // 평가 오류 (40001 ~ 49999)
     // KPI 오류
     STATISTICS_NOT_FOUND("40001", "해당 조건에 대한 KPI 통계가 없습니다.", HttpStatus.NOT_FOUND),

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/command/application/controller/ApproveCommandControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/command/application/controller/ApproveCommandControllerTest.java
@@ -1,0 +1,50 @@
+package com.dao.momentum.approve.command.application.controller;
+
+import com.dao.momentum.approve.command.application.service.ApprovalDecisionCommandService;
+import com.dao.momentum.approve.command.application.service.ApproveCommandService;
+import com.dao.momentum.approve.command.application.service.OcrService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApproveCommandController.class)
+@AutoConfigureMockMvc
+class ApproveCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApproveCommandService approveCommandService;
+
+    @MockitoBean
+    private OcrService ocrService;
+
+    @MockitoBean
+    private ApprovalDecisionCommandService approvalDecisionCommandService;
+
+    @DisplayName("참조 결재 열람")
+    @WithMockUser(username = "1")
+    @Test
+    void viewAsReference_success() throws Exception {
+        Long documentId = 1L;
+        Long empId      = 1L;
+
+        mockMvc.perform(patch("/approval/documents/{documentId}/reference", documentId).with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(approveCommandService).viewAsReference(documentId, empId);
+    }
+}

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImplTest.java
@@ -1,0 +1,145 @@
+package com.dao.momentum.approve.command.application.service;
+
+import com.dao.momentum.approve.command.application.dto.request.*;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategyDispatcher;
+import com.dao.momentum.approve.command.domain.aggregate.*;
+import com.dao.momentum.approve.command.domain.repository.*;
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApproveCommandServiceImplTest {
+
+    @Mock
+    private FormDetailStrategyDispatcher dispatcher;
+
+    @Mock
+    private ApproveRepository approveRepository;
+
+    @Mock
+    private ApproveLineRepository approveLineRepository;
+
+    @Mock
+    private ApproveLineListRepository approveLineListRepository;
+
+    @Mock
+    private ApproveRefRepository approveRefRepository;
+
+    @Mock
+    private FormDetailStrategy formDetailStrategy;
+
+    @InjectMocks
+    private ApproveCommandServiceImpl approveCommandService;
+
+    @Test
+    @DisplayName("결재 생성 성공 테스트")
+    void createApprovalSuccess() {
+        ApproveRequest request = ApproveRequest.builder()
+                .approveTitle("독서 동호회 신청")
+                .approveType(ApproveType.PROPOSAL)
+                .formDetail(mock(com.fasterxml.jackson.databind.JsonNode.class))
+                .approveLineLists(List.of(ApproveLineRequest.builder()
+                        .approveLineOrder(1)
+                        .isRequiredAll(IsRequiredAll.REQUIRED)
+                        .approveLineList(List.of(ApproveLineListRequest.builder().empId(100L).build()))
+                        .build()))
+                .refRequests(List.of(ApproveRefRequest.builder().empId(200L).build()))
+                .build();
+
+        when(dispatcher.dispatch(ApproveType.PROPOSAL)).thenReturn(formDetailStrategy);
+
+        doNothing().when(formDetailStrategy).saveDetail(any(), anyLong());
+
+        when(approveRepository.save(any())).thenAnswer(invocation -> {
+            Approve a = invocation.getArgument(0);
+
+            // 리플렉션으로 approveId 필드 강제 설정 (테스트에서만 사용되기 때문에 실제 코드에는 영향이 없는 부분)
+            java.lang.reflect.Field field = a.getClass().getDeclaredField("approveId");
+            field.setAccessible(true);
+            field.set(a, 1L);
+
+            return a;
+        });
+
+        approveCommandService.createApproval(request, 1L);
+
+        verify(approveRepository, times(1)).save(any());
+        verify(formDetailStrategy, times(1)).saveDetail(any(), eq(1L));
+        verify(approveLineRepository, times(1)).save(any());
+        verify(approveLineListRepository, times(1)).save(any());
+        verify(approveRefRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("취소 결재인데 부모 ID 없으면 예외 발생")
+    void createApprovalCancelWithoutParentThrows() {
+        ApproveRequest request = ApproveRequest.builder()
+                .approveType(ApproveType.CANCEL)
+                .approveTitle("취소 테스트")
+                .formDetail(mock(com.fasterxml.jackson.databind.JsonNode.class))
+                .approveLineLists(List.of())
+                .build();
+
+        ApproveException exception = assertThrows(
+                ApproveException.class,
+                () -> approveCommandService.createApproval(request, 1L)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PARENT_APPROVE_ID_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("결재 문서 참조하기 테스트")
+    void viewAsReferenceTest() {
+        Long approveId = 1L;
+        Long empId = 1L;
+
+        ApproveRef approveRef = ApproveRef.builder()
+                .empId(empId)
+                .approveId(approveId)
+                .isConfirmed(IsConfirmed.N)
+                .build();
+
+        when(approveRefRepository.getApproveRefByApproveIdAndEmpId(approveId, empId))
+                .thenReturn(Optional.ofNullable(approveRef));
+
+
+        approveCommandService.viewAsReference(approveId, empId);
+
+        assert approveRef != null;
+        assertEquals(IsConfirmed.Y, approveRef.getIsConfirmed(), "참조 확인 후 상태가 Y 이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("참조자가 없을 경우 발생하는 에러")
+    void viewAsReferenceNotFoundTest() {
+        Long approveId = 1L;
+        Long empId     = 2L;
+
+        when(approveRefRepository.getApproveRefByApproveIdAndEmpId(approveId, empId))
+                .thenReturn(Optional.empty());
+
+        ApproveException exception = assertThrows(
+                ApproveException.class,
+                () -> approveCommandService.viewAsReference(approveId, empId)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_EXIST_REF);
+
+
+    }
+}


### PR DESCRIPTION
closes #225 
---

📌 개요
 참조자로 설정된 문서를 열람 시  참조 상태를 '열람됨'으로 변경하는 기능

🔨 주요 변경 사항
- `ApproveCommandController`
   - `/approvals/documents/{documentId}/reference` 로 endpoint 설정
   - 컨트롤러 테스트 완료
- `ApproveCommandService`, `ApproveCommandServiceImpl`
   - `viewAsReference` 메소드를 생성
   - `ApproveRef`에서 열람 여부 상태를 변경해주는 `updateRefStatus` 메소드 생성
   - 서비스 테스트 완료 (상태 변경, 예외 테스트)
  
✅ 리뷰 요청 사항
로직 점검

⭐ 관련 이슈
#225 
