### PR TITLE
refactor : 결재 문서 조회 요청, 응답 객체에 description 추가

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
@@ -2,8 +2,6 @@ package com.dao.momentum.approve.query.dto;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Getter
 @ToString
 @NoArgsConstructor

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineListDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveLineListDTO.java
@@ -1,12 +1,6 @@
 package com.dao.momentum.approve.query.dto;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Getter
 @ToString

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
@@ -1,6 +1,5 @@
 package com.dao.momentum.approve.query.dto;
 
-import com.dao.momentum.approve.command.domain.aggregate.IsConfirmed;
 import lombok.*;
 
 @Getter

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.query.dto.request;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -9,19 +10,38 @@ import java.time.LocalDate;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "결재 목록 request")
 public class ApproveListRequest {
 
     @NotNull(message = "결재 종류는 반드시 선택해야 합니다.")
+    @Schema(description = "탭 구분")
     private final String tab;
 
+    @Schema(description = "결재 문서 종류")
     private final ApproveType approveType;
+
+    @Schema(description = "영수증 종류")
     private final String receiptType;
+
+    @Schema(description = "결재 상태 ID", example = "1")
     private final Integer status;
+
+    @Schema(description = "결재 제목 검색어")
     private final String title;
+
+    @Schema(description = "기안자 이름 검색어")
     private final String employeeName;
+
+    @Schema(description = "기안자 소속 부서 이름", example = "기획팀")
     private final String departmentName;
+
+    @Schema(description = "검색 시작일")
     private final LocalDate startDate;
+
+    @Schema(description = "검색 종료일")
     private final LocalDate endDate;
+
+    @Schema(description = "정렬 방식")
     private final String sort;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/DraftApproveListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/DraftApproveListRequest.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,17 +11,32 @@ import java.time.LocalDate;
 @Getter
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "결재 목록 request")
 public class DraftApproveListRequest {
 
     @NotNull(message = "결재 종류는 반드시 선택해야 합니다.")
+    @Schema(description = "탭 구분 값")
     private final String tab;
 
+    @Schema(description = "결재 문서 종류")
     private final String approveType;
+
+    @Schema(description = "영수증 종류")
     private final String receiptType;
+
+    @Schema(description = "결재 상태", example = "1")
     private final Integer status;
+
+    @Schema(description = "결재 제목 필터링을 위한 검색어")
     private final String title;
+
+    @Schema(description = "검색 기간의 시작일")
     private final LocalDate startDate;
+
+    @Schema(description = "검색 기간의 종료일")
     private final LocalDate endDate;
+
+    @Schema(description = "정렬 방식 지정(오름차순/내림차순)")
     private final String sort;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/PageRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/PageRequest.java
@@ -1,9 +1,11 @@
 package com.dao.momentum.approve.query.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import lombok.*;
 
 @Getter
+@Schema(description = "페이지 request")
 public class PageRequest {
 
     @Min(value = 1)

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveDetailResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveDetailResponse.java
@@ -1,6 +1,7 @@
 package com.dao.momentum.approve.query.dto.response;
 
 import com.dao.momentum.approve.query.dto.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,13 +9,25 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "결재 상세 응답 객체")
 public class ApproveDetailResponse {
 
+    @Schema(description = "결재 정보 DTO")
     private ApproveDTO approveDTO;
+
+    @Schema(description = "부모 결재 정보 DTO")
     private ApproveDTO parentApproveDTO;
+
+    @Schema(description = "결재에 첨부된 파일 목록 DTO")
     private List<ApproveFileDTO> approveFileDTO;
+
+    @Schema(description = "결재 라인 그룹 목록 DTO")
     private List<ApproveLineGroupDTO> approveLineGroupDTO;
+
+    @Schema(description = "결재 참조자 목록 DTO")
     private List<ApproveRefDTO> approveRefDTO;
-    private Object formDetail; // 폼의 종류에 따라서 상세 정보가 달라짐
+
+    @Schema(description = "폼 상세 정보 (폼 종류에 따라 내용이 달라짐)")
+    private Object formDetail;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/ApproveResponse.java
@@ -2,6 +2,7 @@ package com.dao.momentum.approve.query.dto.response;
 
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.common.dto.Pagination;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,9 +10,13 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "결재 목록 응답 객체")
 public class ApproveResponse {
 
+    @Schema(description = "결재 목록 데이터 DTO 리스트")
     private List<ApproveDTO> approveDTO;
+
+    @Schema(description = "페이징 정보")
     private Pagination pagination;
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/DraftApproveResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/DraftApproveResponse.java
@@ -2,6 +2,7 @@ package com.dao.momentum.approve.query.dto.response;
 
 import com.dao.momentum.approve.query.dto.DraftApproveDTO;
 import com.dao.momentum.common.dto.Pagination;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,9 +10,13 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "보낸 결재 목록 응답 객체")
 public class DraftApproveResponse {
 
+    @Schema(description = "보낸 결재 목록 DTO 리스트")
     private List<DraftApproveDTO> draftApproveDTO;
+
+    @Schema(description = "페이징 정보")
     private Pagination pagination;
 
 }


### PR DESCRIPTION
closes #000
---

📌 개요
결재 문서 조회 요청, 응답 객체에 description 추가 및 불필요한 import 제거

🔨 주요 변경 사항
- 결재 DTO 객체에 불필요한 import 제거
- request 객체
  - `ApproveListRequest`
  - `DraftApproveListRequest`
  - `PageRequest`
- response 객체
  - `ApproveDetailResponse`
  - `ApproveResponse`
  - `DraftApproveResponse`

✅ 리뷰 요청 사항

⭐ 관련 이슈
#3 #6 #7 
