### PR TITLE
feat: 사원의 잔여 연차, 리프레시 휴가 조회 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/RemainingVacationQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/RemainingVacationQueryController.java
@@ -1,0 +1,45 @@
+package com.dao.momentum.approve.query.controller;
+
+import com.dao.momentum.approve.query.dto.response.DayoffResponse;
+import com.dao.momentum.approve.query.dto.response.RefreshResponse;
+import com.dao.momentum.approve.query.service.RemainingVacationQueryService;
+import com.dao.momentum.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/employees")
+@Tag(name = "잔여 휴가 시간 조회", description ="잔여 휴가 시간 조회 API")
+@RequiredArgsConstructor
+public class RemainingVacationQueryController {
+
+    private final RemainingVacationQueryService remainingVacationQueryService;
+
+    /* 잔여 연차 시간 조회 */
+    @GetMapping("/{empId}/dayoff")
+    @Operation(summary = "잔여 연차 시간 조회", description ="사원의 잔여 연차 시간을 조회합니다.")
+    public ResponseEntity<ApiResponse<DayoffResponse>> getRemainingDayoffs(
+            @PathVariable long empId
+    ) {
+        DayoffResponse response = remainingVacationQueryService.getRemainingDayoffs(empId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /* 잔여 리프레시 휴가 일수 조회*/
+    @GetMapping("/{empId}/refresh")
+    @Operation(summary = "잔여 리프레시 휴가 일수 조회", description ="사원의 잔여 리프레시 휴가 일수를 조회합니다.")
+    public ResponseEntity<ApiResponse<RefreshResponse>> getRemainingRefreshs(
+            @PathVariable long empId
+    ) {
+        RefreshResponse response = remainingVacationQueryService.getRemainingRefreshs(empId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/DayoffResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/DayoffResponse.java
@@ -1,0 +1,16 @@
+package com.dao.momentum.approve.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "잔여 연차 응답 객체")
+public class DayoffResponse {
+    @Schema(description = "사원 ID", example = "1")
+    private long empId;
+
+    @Schema(description = "잔여 연차 시간", example = "120")
+    private int remainingDayoffHours;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/RefreshResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/response/RefreshResponse.java
@@ -1,0 +1,16 @@
+package com.dao.momentum.approve.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "잔여 리프레시 휴가 응답 객체")
+public class RefreshResponse {
+    @Schema(description = "사원 ID", example = "1")
+    private long empId;
+
+    @Schema(description = "잔여 리프레시 휴가 일수", example = "2")
+    private int remainingRefreshDays;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/VacationMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/VacationMapper.java
@@ -1,0 +1,10 @@
+package com.dao.momentum.approve.query.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface VacationMapper {
+    int getRemainingDayoffs(long empId);
+
+    int getRemainingRefreshs(long empId);
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/RemainingVacationQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/RemainingVacationQueryService.java
@@ -1,0 +1,13 @@
+package com.dao.momentum.approve.query.service;
+
+import com.dao.momentum.approve.query.dto.response.DayoffResponse;
+import com.dao.momentum.approve.query.dto.response.RefreshResponse;
+
+public interface RemainingVacationQueryService {
+
+    /* 잔여 연차 시간을 조회하는 메서드 */
+    DayoffResponse getRemainingDayoffs(long empId);
+
+    /* 잔여 리프레시 휴가 일수를 조회하는 메서드 */
+    RefreshResponse getRemainingRefreshs(long empId);
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/RemainingVacationQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/RemainingVacationQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package com.dao.momentum.approve.query.service;
+
+import com.dao.momentum.approve.query.dto.response.DayoffResponse;
+import com.dao.momentum.approve.query.dto.response.RefreshResponse;
+import com.dao.momentum.approve.query.mapper.VacationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RemainingVacationQueryServiceImpl implements RemainingVacationQueryService {
+    private final VacationMapper vacationMapper;
+
+    @Override
+    public DayoffResponse getRemainingDayoffs(long empId) {
+        int remainingDayoffHours = vacationMapper.getRemainingDayoffs(empId);
+
+        return DayoffResponse.builder()
+                .empId(empId)
+                .remainingDayoffHours(remainingDayoffHours)
+                .build();
+    }
+
+    @Override
+    public RefreshResponse getRemainingRefreshs(long empId) {
+        int remainingRefreshDays = vacationMapper.getRemainingRefreshs(empId);
+
+        return RefreshResponse.builder()
+                .empId(empId)
+                .remainingRefreshDays(remainingRefreshDays)
+                .build();
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/controller/WorkQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/controller/WorkQueryController.java
@@ -3,9 +3,11 @@ package com.dao.momentum.work.query.controller;
 import com.dao.momentum.common.dto.ApiResponse;
 import com.dao.momentum.work.query.dto.request.AdminWorkSearchRequest;
 import com.dao.momentum.work.query.dto.request.WorkSearchRequest;
+import com.dao.momentum.work.query.dto.response.AttendanceResponse;
 import com.dao.momentum.work.query.dto.response.WorkDetailsResponse;
 import com.dao.momentum.work.query.dto.response.WorkListResponse;
 import com.dao.momentum.work.query.service.WorkQueryService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/works")
@@ -31,6 +36,37 @@ public class WorkQueryController {
         return ResponseEntity.ok(
                 ApiResponse.success(
                         workQueryService.getMyWorks(userDetails, workSearchRequest)
+                )
+        );
+    }
+
+    @GetMapping("/me/today")
+    @Operation(summary = "당일 출근 여부 조회", description = "사원이 자신의 출근 등록 여부를 조회합니다.")
+    public ResponseEntity<ApiResponse<AttendanceResponse>> getMyTodaysAttendance(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        LocalDate today = LocalDate.now();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        workQueryService.getMyTodaysAttendance(userDetails, today)
+                )
+        );
+    }
+
+    @Hidden
+    @GetMapping("/me/today/test") // 개발자 테스트용
+    public ResponseEntity<ApiResponse<AttendanceResponse>> getMyTodaysAttendanceTest(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) LocalDate today
+    ) {
+        if (today == null) {
+            today = LocalDate.now();
+        }
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        workQueryService.getMyTodaysAttendance(userDetails, today)
                 )
         );
     }
@@ -60,7 +96,6 @@ public class WorkQueryController {
                 )
         );
     }
-
 
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/AttendanceDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/AttendanceDTO.java
@@ -1,0 +1,12 @@
+package com.dao.momentum.work.query.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class AttendanceDTO {
+    private IsAttended isAttended;
+
+    private Long empId;
+
+    private Long workId;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/AttendanceResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/AttendanceResponse.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.work.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "당일 출근 여부 응답 객체")
+public class AttendanceResponse {
+    @Schema(description = "출근 여부")
+    private IsAttended isAttended;
+
+    @Schema(description = "사원 ID", example = "1")
+    private long empId;
+
+    @Schema(description = "출퇴근 ID", example = "1")
+    private Long workId;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/IsAttended.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/IsAttended.java
@@ -1,0 +1,5 @@
+package com.dao.momentum.work.query.dto.response;
+
+public enum IsAttended {
+    Y, N
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/mapper/WorkMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/mapper/WorkMapper.java
@@ -2,11 +2,13 @@ package com.dao.momentum.work.query.mapper;
 
 import com.dao.momentum.work.query.dto.request.AdminWorkSearchDTO;
 import com.dao.momentum.work.query.dto.request.WorkSearchDTO;
+import com.dao.momentum.work.query.dto.response.AttendanceDTO;
 import com.dao.momentum.work.query.dto.response.WorkDTO;
 import com.dao.momentum.work.query.dto.response.WorkDetailsDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Mapper
@@ -18,4 +20,6 @@ public interface WorkMapper {
     long countWorks(@Param("request") AdminWorkSearchDTO request);
 
     WorkDetailsDTO getWorkDetails(long workId);
+
+    AttendanceDTO getMyTodaysAttendance(long empId, LocalDate today, LocalDate tomorrow);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/service/WorkQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/service/WorkQueryService.java
@@ -5,16 +5,14 @@ import com.dao.momentum.work.query.dto.request.AdminWorkSearchDTO;
 import com.dao.momentum.work.query.dto.request.AdminWorkSearchRequest;
 import com.dao.momentum.work.query.dto.request.WorkSearchDTO;
 import com.dao.momentum.work.query.dto.request.WorkSearchRequest;
-import com.dao.momentum.work.query.dto.response.WorkDTO;
-import com.dao.momentum.work.query.dto.response.WorkDetailsDTO;
-import com.dao.momentum.work.query.dto.response.WorkDetailsResponse;
-import com.dao.momentum.work.query.dto.response.WorkListResponse;
+import com.dao.momentum.work.query.dto.response.*;
 import com.dao.momentum.work.query.mapper.WorkMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -66,6 +64,20 @@ public class WorkQueryService {
 
         return WorkDetailsResponse.builder()
                 .workDetails(workDetails)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AttendanceResponse getMyTodaysAttendance(UserDetails userDetails, LocalDate today) {
+        long empId = Long.parseLong(userDetails.getUsername());
+        LocalDate tomorrow = today.plusDays(1);
+
+        AttendanceDTO attendance = workMapper.getMyTodaysAttendance(empId, today, tomorrow);
+
+        return AttendanceResponse.builder()
+                .isAttended(attendance.getIsAttended())
+                .empId(empId)
+                .workId(attendance.getWorkId())
                 .build();
     }
 }

--- a/momentum-dao-be/src/main/resources/mappers/approve/VacationMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/VacationMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.approve.query.mapper.VacationMapper">
+    <!-- 잔여 연차 일수  -->
+    <select id="getRemainingDayoffs" resultType="int">
+        SELECT
+            remaining_dayoff_hours
+        FROM employee
+        WHERE emp_id = #{empId}
+    </select>
+
+    <!-- 잔여 리프레시 휴가 일수  -->
+    <select id="getRemainingRefreshs" resultType="int">
+        SELECT
+            remaining_refresh_days
+        FROM employee
+        WHERE emp_id = #{empId}
+    </select>
+
+</mapper>

--- a/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
@@ -107,4 +107,31 @@
         FROM work
         WHERE work_id = #{workId}
     </select>
+
+    <select id="getMyTodaysAttendance" resultType="com.dao.momentum.work.query.dto.response.AttendanceDTO">
+        SELECT
+            'Y' AS isAttended,
+            work.work_id,
+            work.emp_id
+        FROM work AS work
+        WHERE work.emp_id = #{empId}
+        AND work.start_at &gt;= #{today}
+        AND work.start_at &lt; #{tomorrow}
+
+        UNION ALL
+
+        SELECT
+            'N' AS isAttended,
+            null AS workId,
+            null AS empId
+        FROM DUAL
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM work
+            WHERE emp_id = #{empId}
+            AND work.start_at &gt;= #{today}
+            AND work.start_at &lt; #{tomorrow}
+        )
+        LIMIT 1
+    </select>
 </mapper>

--- a/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
@@ -114,9 +114,11 @@
             work.work_id,
             work.emp_id
         FROM work AS work
+        JOIN work_type AS wt ON work.type_id = wt.type_id
         WHERE work.emp_id = #{empId}
         AND work.start_at &gt;= #{today}
         AND work.start_at &lt; #{tomorrow}
+        AND wt.type_name = 'WORK'
 
         UNION ALL
 
@@ -128,9 +130,11 @@
         WHERE NOT EXISTS (
             SELECT 1
             FROM work
+            JOIN work_type AS wt ON work.type_id = wt.type_id
             WHERE emp_id = #{empId}
             AND work.start_at &gt;= #{today}
             AND work.start_at &lt; #{tomorrow}
+            AND wt.type_name = 'WORK'
         )
         LIMIT 1
     </select>


### PR DESCRIPTION
closes #252

---

📌 개요
- 사원의 잔여 연차, 리프레시 휴가 조회 기능 구현

🔨 주요 변경 사항
- appove 하위에 컨트롤러, 서비스, mapper, xml 쿼리, dto 작성

✅ 리뷰 요청 사항
- 쿼리, 엔드포인트 이름 적절한 지 (필요 시 url 변경 혹은 employee 하위로 이동)
- 권한 체크 추가 필요한 지 (현재는 로그인 유저에게 open 된 엔드포인트)

- 참고: 커밋 순서 꼬여서 work 쪽 PR (#274) 수정 사항이 함께 묶여있습니다.

⭐ 관련 이슈
#252
