### PR TITLE
feat : 사원의 팀장 조회하기

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.controller;
 
+import com.dao.momentum.approve.query.dto.EmployeeLeaderDto;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
@@ -72,8 +73,21 @@ public class ApproveQueryController {
         ApproveDetailResponse approveDetailResponse
                 = approveQueryService.getApproveDetail(documentId);
 
-
         return ResponseEntity.ok(ApiResponse.success(approveDetailResponse));
+    }
+
+    /* 사원의 팀장 조회 기능 */
+    @GetMapping("/leader")
+    @Operation(
+            summary = "사원의 팀장 조회",
+            description = "사원의 팀장을 조회합니다. 만약 팀장 권한을 가지고 있는 사원이라면 상위 부서의 팀장을 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<EmployeeLeaderDto>> getLeader(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.success(approveQueryService.getEmployeeLeader(empId)));
     }
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/EmployeeLeaderDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/EmployeeLeaderDto.java
@@ -1,0 +1,15 @@
+package com.dao.momentum.approve.query.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmployeeLeaderDto {
+
+    private Long teamLeaderId;
+    private String teamLeaderName;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveMapper.java
@@ -1,0 +1,11 @@
+package com.dao.momentum.approve.query.mapper;
+
+import com.dao.momentum.approve.query.dto.EmployeeLeaderDto;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ApproveMapper {
+
+    EmployeeLeaderDto findEmployeeLeader(Long empId);
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
@@ -1,5 +1,6 @@
 package com.dao.momentum.approve.query.service;
 
+import com.dao.momentum.approve.query.dto.EmployeeLeaderDto;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.PageRequest;
@@ -25,5 +26,9 @@ public interface ApproveQueryService {
 
     /* 결재 상세 조회 메서드 */
     ApproveDetailResponse getApproveDetail(Long approveId);
+
+
+    /* 사원의 팀장 조회 메서드 */
+    EmployeeLeaderDto getEmployeeLeader(Long empId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
@@ -12,6 +12,7 @@ import com.dao.momentum.approve.query.dto.response.ApproveDetailResponse;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
 import com.dao.momentum.approve.query.mapper.ApproveDetailMapper;
+import com.dao.momentum.approve.query.mapper.ApproveMapper;
 import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.common.dto.Pagination;
@@ -32,6 +33,7 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
     private final ReceivedApproveMapper receivedApproveMapper;
     private final DraftApproveMapper draftApproveMapper;
     private final ApproveDetailMapper approveDetailMapper;
+    private final ApproveMapper approveMapper;
 
     /* 받은 결재 목록을 조회하는 메서드 */
     @Transactional(readOnly = true)
@@ -152,6 +154,12 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
         Object formDetail = resolveFormDetail(ApproveType.CANCEL,cancelApproveId);
 
         return buildApproveDetailResponse(cancelDTO, parentDTO, approveFileDTO, lineList, refList, formDetail);
+    }
+
+
+    @Transactional(readOnly = true)
+    public EmployeeLeaderDto getEmployeeLeader(Long empId) {
+        return approveMapper.findEmployeeLeader(empId);
     }
 
     /* 일반 결재인 경우 */

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.dao.momentum.approve.query.mapper.ApproveMapper">
+
+    <select id="findEmployeeLeader" resultType="com.dao.momentum.approve.query.dto.EmployeeLeaderDto">
+        SELECT
+            -- 상위 결재자의 이름 + 직위명
+            CASE
+                WHEN e.dept_id = 1 AND e.position_id BETWEEN 2 AND 4 THEN CONCAT(ceo.name, ' ', p_ceo.name, '님')
+                WHEN e.position_id BETWEEN 2 AND 4 THEN CONCAT(eh_sup.name, ' ', p_sup.name, '님')
+                ELSE CONCAT(eh_cur.name, ' ', p_cur.name)
+            END AS team_leader_name,
+
+            -- 상위 결재자의 사번
+            CASE
+                WHEN e.dept_id = 1 AND e.position_id BETWEEN 2 AND 4 THEN ceo.emp_id
+                WHEN e.position_id BETWEEN 2 AND 4 THEN dh_sup.emp_id
+                ELSE dh_cur.emp_id
+            END AS team_leader_id
+
+        FROM employee e
+
+        JOIN department d ON e.dept_id = d.dept_id
+        LEFT JOIN department d_sup ON d.parent_dept_id = d_sup.dept_id
+
+        LEFT JOIN dept_head dh_cur ON e.dept_id = dh_cur.dept_id
+        LEFT JOIN employee eh_cur ON dh_cur.emp_id = eh_cur.emp_id
+        LEFT JOIN position p_cur ON eh_cur.position_id = p_cur.position_id
+
+        LEFT JOIN dept_head dh_sup ON d_sup.dept_id = dh_sup.dept_id
+        LEFT JOIN employee eh_sup ON dh_sup.emp_id = eh_sup.emp_id
+        LEFT JOIN position p_sup ON eh_sup.position_id = p_sup.position_id
+
+        LEFT JOIN employee ceo ON ceo.emp_id = 1
+        LEFT JOIN position p_ceo ON ceo.position_id = p_ceo.position_id
+
+        WHERE e.emp_id = #{empId}
+    </select>
+
+</mapper>

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveQueryControllerTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/controller/ApproveQueryControllerTest.java
@@ -3,6 +3,7 @@ package com.dao.momentum.approve.query.controller;
 import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.query.dto.ApproveDTO;
 import com.dao.momentum.approve.query.dto.DraftApproveDTO;
+import com.dao.momentum.approve.query.dto.EmployeeLeaderDto;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
 import com.dao.momentum.approve.query.service.ApproveQueryService;
@@ -21,6 +22,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -98,6 +102,27 @@ class ApproveQueryControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.draftApproveDTO[0].approveTitle").value("점심 식사 영수증"))
                 .andExpect(jsonPath("$.data.draftApproveDTO[1].approveTitle").value("출장 택시비"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+
+    }
+    @WithMockUser(username = "1")
+    @DisplayName("사원의 팀장 조회 테스트")
+    @Test
+    void testGetEmployeeLeader() throws Exception {
+        EmployeeLeaderDto employeeLeaderDto = EmployeeLeaderDto.builder()
+                .teamLeaderId(2L)
+                .teamLeaderName("정유진 과장님")
+                .build();
+
+        Mockito.when(approveQueryService.getEmployeeLeader(Mockito.any()))
+                .thenReturn(employeeLeaderDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/approval/leader"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.teamLeaderId").value(2L))
+                .andExpect(jsonPath("$.data.teamLeaderName").value("정유진 과장님"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
@@ -12,6 +12,7 @@ import com.dao.momentum.approve.query.dto.response.ApproveDetailResponse;
 import com.dao.momentum.approve.query.dto.response.ApproveResponse;
 import com.dao.momentum.approve.query.dto.response.DraftApproveResponse;
 import com.dao.momentum.approve.query.mapper.ApproveDetailMapper;
+import com.dao.momentum.approve.query.mapper.ApproveMapper;
 import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.organization.employee.exception.EmployeeException;
@@ -42,6 +43,9 @@ class ApproveQueryServiceImplTest {
 
     @Mock
     private ApproveDetailMapper approveDetailMapper;
+
+    @Mock
+    private ApproveMapper approveMapper;
 
     @InjectMocks
     private ApproveQueryServiceImpl approveService;
@@ -202,6 +206,25 @@ class ApproveQueryServiceImplTest {
         assertNotNull(result);
         assertEquals(approveDTO, result.getApproveDTO());
         assertEquals(formDetail, result.getFormDetail());
+    }
+
+    @Test
+    @DisplayName("사원의 팀장 조회 테스트")
+    void testGetEmployeeLeader() {
+        Long empId = 1L;
+
+        EmployeeLeaderDto employeeLeaderDto = EmployeeLeaderDto.builder()
+                .teamLeaderId(2L)
+                .teamLeaderName("정유진 과장님")
+                .build();
+
+        when(approveMapper.findEmployeeLeader(empId)).thenReturn(employeeLeaderDto);
+
+        EmployeeLeaderDto result = approveService.getEmployeeLeader(empId);
+
+        assertNotNull(result);
+        assertEquals(2L, result.getTeamLeaderId());
+        assertEquals("정유진 과장님", result.getTeamLeaderName());
     }
 
 


### PR DESCRIPTION
closes #218 

---

📌 개요
결재 문서 작성 시 팀장을 default로 설정하기 위해 사원의 팀장 조회하기

🔨 주요 변경 사항
- `ApproveQueryController`
  - `/approval/leader`로 엔드포인트 설정
  - 테스트 완료
- `ApproveQueryService`,  `ApproveQueryServiceImpl`
  - 팀장을 조회하는 `getEmployeeLeader` 메소드 생성
  - 테스트 완료 
- `ApprvoeMapper.java`, `ApproveMapper.java`
  - `findEmployeeLeader` 메소드 생성 및 쿼리 작성
- `EmployeeLeaderDto` 
  - 팀장의 사번과 이름 

✅ 리뷰 요청 사항
로직 점검 

⭐ 관련 이슈
#218
