### PR TITLE
fix :  상위 부서 선택 시 하위 부서까지 조회될 수 있게 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/AdminApproveQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/AdminApproveQueryController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/request/ApproveListRequest.java
@@ -32,8 +32,8 @@ public class ApproveListRequest {
     @Schema(description = "기안자 이름 검색어")
     private final String employeeName;
 
-    @Schema(description = "기안자 소속 부서 이름", example = "기획팀")
-    private final String departmentName;
+    @Schema(description = "기안자 소속 부서 아이디", example = "1")
+    private final Long deptId;
 
     @Schema(description = "검색 시작일")
     private final LocalDate startDate;

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImpl.java
@@ -43,7 +43,7 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
     ) {
 
         // 존재하지 않는 결재 탭을 입력하는 경우 에러 처리
-        List<String> validTabs = List.of("ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
+        List<String> validTabs = List.of("ALL", "ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
 
         if (!validTabs.contains(approveListRequest.getTab())) {
             throw new NotExistTabException(ErrorCode.NOT_EXIST_TAB);
@@ -84,7 +84,7 @@ public class ApproveQueryServiceImpl implements ApproveQueryService {
     ) {
 
         // 존재하지 않는 결재 탭을 입력하는 경우 에러 처리
-        List<String> validTabs = List.of("ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
+        List<String> validTabs = List.of("ALL", "ATTENDANCE", "PROPOSAL", "RECEIPT", "CANCEL");
 
         if (!validTabs.contains(draftApproveListRequest.getTab())) {
             throw new NotExistTabException(ErrorCode.NOT_EXIST_TAB);

--- a/momentum-dao-be/src/main/resources/mappers/approve/AdminApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/AdminApproveMapper.xml
@@ -75,10 +75,22 @@
         </if>
 
         <!-- 부서 -->
-        <if test="req.departmentName != null and req.departmentName != ''">
-            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        <if test="req.deptId != null">
+            AND e.dept_id IN (
+                WITH RECURSIVE dept_tree AS (
+                    SELECT dept_id
+                    FROM department
+                    WHERE dept_id = #{req.deptId}
+                    AND is_deleted = 'N'
+                        UNION ALL
+                    SELECT d.dept_id
+                    FROM department d
+                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+                    WHERE d.is_deleted = 'N'
+                )
+            SELECT dept_id FROM dept_tree
+            )
         </if>
-
         <!-- 완료 날짜를 기준으로 정렬 -->
         ORDER BY
         <choose>
@@ -101,23 +113,26 @@
 
         WHERE 1=1
 
-        <if test="req.tab == 'ATTENDANCE'">
-            AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
-            <if test="req.approveType != null and req.approveType != ''">
-                AND a.approve_type = #{req.approveType}
+        <if test="req.tab != 'ALL'">
+            <if test="req.tab == 'ATTENDANCE'">
+                AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
+                <!-- 근태 관련된 상세 필터 -->
+                <if test="req.approveType != null and req.approveType != ''">
+                    AND a.approve_type = #{req.approveType}
+                </if>
             </if>
-        </if>
-        <if test="req.tab == 'PROPOSAL'">
-            AND a.approve_type = 'PROPOSAL'
-        </if>
-        <if test="req.tab == 'RECEIPT'">
-            AND a.approve_type = 'RECEIPT'
-            <if test="req.receiptType != null and req.receiptType != ''">
-                AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+            <if test="req.tab == 'PROPOSAL'">
+                AND a.approve_type = 'PROPOSAL'
             </if>
-        </if>
-        <if test="req.tab == 'CANCEL'">
-            AND a.approve_type = 'CANCEL'
+            <if test="req.tab == 'RECEIPT'">
+                AND a.approve_type = 'RECEIPT'
+                <if test="req.receiptType != null and req.receiptType != ''">
+                    AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+                </if>
+            </if>
+            <if test="req.tab == 'CANCEL'">
+                AND a.approve_type = 'CANCEL'
+            </if>
         </if>
 
         <if test="req.status != null">
@@ -142,8 +157,21 @@
             AND a.create_at &lt; #{req.endDate}
         </if>
 
-        <if test="req.departmentName != null and req.departmentName != ''">
-            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        <if test="req.deptId != null">
+            AND e.dept_id IN (
+                WITH RECURSIVE dept_tree AS (
+                    SELECT dept_id
+                    FROM department
+                    WHERE dept_id = #{req.deptId}
+                    AND is_deleted = 'N'
+                        UNION ALL
+                    SELECT d.dept_id
+                    FROM department d
+                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+                    WHERE d.is_deleted = 'N'
+                )
+            SELECT dept_id FROM dept_tree
+            )
         </if>
     </select>
 

--- a/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
@@ -27,24 +27,26 @@
         WHERE ali.emp_id = #{empId}
 
         <!-- 탭 조건 -->
-        <if test="req.tab == 'ATTENDANCE'">
-            AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
-            <!-- 근태 관련된 상세 필터 -->
-            <if test="req.approveType != null and req.approveType != ''">
-                AND a.approve_type = #{req.approveType}
+        <if test="req.tab != 'ALL'">
+            <if test="req.tab == 'ATTENDANCE'">
+                AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
+                <!-- 근태 관련된 상세 필터 -->
+                <if test="req.approveType != null and req.approveType != ''">
+                    AND a.approve_type = #{req.approveType}
+                </if>
             </if>
-        </if>
-        <if test="req.tab == 'PROPOSAL'">
-            AND a.approve_type = 'PROPOSAL'
-        </if>
-        <if test="req.tab == 'RECEIPT'">
-            AND a.approve_type = 'RECEIPT'
-            <if test="req.receiptType != null and req.receiptType != ''">
-                AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+            <if test="req.tab == 'PROPOSAL'">
+                AND a.approve_type = 'PROPOSAL'
             </if>
-        </if>
-        <if test="req.tab == 'CANCEL'">
-            AND a.approve_type = 'CANCEL'
+            <if test="req.tab == 'RECEIPT'">
+                AND a.approve_type = 'RECEIPT'
+                <if test="req.receiptType != null and req.receiptType != ''">
+                    AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+                </if>
+            </if>
+            <if test="req.tab == 'CANCEL'">
+                AND a.approve_type = 'CANCEL'
+            </if>
         </if>
 
         <!-- 상태  -->
@@ -74,8 +76,21 @@
         </if>
 
         <!-- 부서 -->
-        <if test="req.departmentName != null and req.departmentName != ''">
-            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        <if test="req.deptId != null">
+            AND e.dept_id IN (
+                WITH RECURSIVE dept_tree AS (
+                    SELECT dept_id
+                    FROM department
+                    WHERE dept_id = #{req.deptId}
+                    AND is_deleted = 'N'
+                        UNION ALL
+                    SELECT d.dept_id
+                    FROM department d
+                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+                    WHERE d.is_deleted = 'N'
+                )
+            SELECT dept_id FROM dept_tree
+            )
         </if>
 
         <!-- 완료 날짜를 기준으로 정렬 -->
@@ -101,23 +116,27 @@
         JOIN approve_line_list ali ON al.approve_line_id = ali.approve_line_id
 
         WHERE ali.emp_id = #{empId}
-        <if test="req.tab == 'ATTENDANCE'">
-            AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
-            <if test="req.approveType != null and req.approveType != ''">
-                AND a.approve_type = #{req.approveType}
+
+        <if test="req.tab != 'ALL'">
+            <if test="req.tab == 'ATTENDANCE'">
+                AND a.approve_type IN ('WORKCORRECTION', 'OVERTIME', 'REMOTEWORK', 'BUSINESSTRIP', 'VACATION')
+                <!-- 근태 관련된 상세 필터 -->
+                <if test="req.approveType != null and req.approveType != ''">
+                    AND a.approve_type = #{req.approveType}
+                </if>
             </if>
-        </if>
-        <if test="req.tab == 'PROPOSAL'">
-            AND a.approve_type = 'PROPOSAL'
-        </if>
-        <if test="req.tab == 'RECEIPT'">
-            AND a.approve_type = 'RECEIPT'
-            <if test="req.receiptType != null and req.receiptType != ''">
-                AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+            <if test="req.tab == 'PROPOSAL'">
+                AND a.approve_type = 'PROPOSAL'
             </if>
-        </if>
-        <if test="req.tab == 'CANCEL'">
-            AND a.approve_type = 'CANCEL'
+            <if test="req.tab == 'RECEIPT'">
+                AND a.approve_type = 'RECEIPT'
+                <if test="req.receiptType != null and req.receiptType != ''">
+                    AND (SELECT ar.receipt_type FROM approve_receipt ar WHERE ar.approve_id = a.approve_id) = #{req.receiptType}
+                </if>
+            </if>
+            <if test="req.tab == 'CANCEL'">
+                AND a.approve_type = 'CANCEL'
+            </if>
         </if>
 
         <if test="req.status != null">
@@ -142,8 +161,21 @@
             AND a.create_at &lt; #{req.endDate}
         </if>
 
-        <if test="req.departmentName != null and req.departmentName != ''">
-            AND d.name LIKE CONCAT('%', #{req.departmentName}, '%')
+        <if test="req.deptId != null">
+            AND e.dept_id IN (
+                WITH RECURSIVE dept_tree AS (
+                    SELECT dept_id
+                    FROM department
+                    WHERE dept_id = #{req.deptId}
+                    AND is_deleted = 'N'
+                        UNION ALL
+                    SELECT d.dept_id
+                    FROM department d
+                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+                    WHERE d.is_deleted = 'N'
+                )
+            SELECT dept_id FROM dept_tree
+            )
         </if>
     </select>
 


### PR DESCRIPTION
closes #3
closes #6

---

📌 개요
결재 목록 조회 시 상위 부서 선택 시 하위 부서까지 조회 될 수 있게 수정

🔨 주요 변경 사항
- 필요없는 import 제거
- 소속 부서 이름 대신 아이디(`deptId`)로 조회할 수 있게  request객체 수정
- `AdminApproveMapper`, `ReceivedApproveMapper`수정 

✅ 리뷰 요청 사항

⭐ 관련 이슈
#3 , #6 
