### PR TITLE
refactor: 사원 목록 조회 쿼리 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/request/EmployeeSearchRequest.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/query/dto/request/EmployeeSearchRequest.java
@@ -12,11 +12,7 @@ import java.time.LocalDate;
 public class EmployeeSearchRequest {
     private Integer deptId;
 
-//    private String deptName;
-
     private Integer positionId;
-
-//    private String positionName;
 
     private UserRoleName userRole;
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/request/AdminWorkSearchDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/request/AdminWorkSearchDTO.java
@@ -14,8 +14,6 @@ public class AdminWorkSearchDTO {
 
     private Integer deptId;
 
-//    private String deptName;
-
     private Integer positionId;
 
     private LocalDate rangeStartDate;
@@ -23,7 +21,7 @@ public class AdminWorkSearchDTO {
     private LocalDate rangeEndDate;
 
     private Integer typeId;
-//    private String typeName;
+
     private Integer childTypeId;
 
     private Integer vacationTypeId;

--- a/momentum-dao-be/src/main/resources/mappers/organization/AdminEmployeeMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/organization/AdminEmployeeMapper.xml
@@ -28,7 +28,14 @@
             AND pos.position_id = #{request.positionId}
         </if>
         <if test="request.userRole != null">
-            AND ur.user_role_name = #{request.userRole}
+            <choose>
+                <when test="request.userRole.name() == 'EMPLOYEE'">
+                    AND ur.user_role_name IS NULL
+                </when>
+                <otherwise>
+                    AND ur.user_role_name = #{request.userRole}
+                </otherwise>
+            </choose>
         </if>
         <if test="request.searchStartDate != null">
             AND emp.join_date &gt;= #{request.searchStartDate}
@@ -45,7 +52,7 @@
                 ORDER BY emp.join_date
             </when>
             <otherwise>
-                ORDER BY emp.emp_id
+                ORDER BY emp.emp_no
             </otherwise>
         </choose>
         <if test="request.order != null and request.order.name() == 'DESC'">
@@ -70,7 +77,14 @@
             AND pos.position_id = #{request.positionId}
         </if>
         <if test="request.userRole != null">
-            AND ur.user_role_name = #{request.userRole}
+            <choose>
+                <when test="request.userRole.name() == 'EMPLOYEE'">
+                    AND ur.user_role_name IS NULL
+                </when>
+                <otherwise>
+                    AND ur.user_role_name = #{request.userRole}
+                </otherwise>
+            </choose>
         </if>
         <if test="request.searchStartDate != null">
             AND emp.join_date &gt;= #{request.searchStartDate}


### PR DESCRIPTION
closes #000

---

📌 개요
- 사원 목록 조회 쿼리 수정

🔨 주요 변경 사항
- 권한 필터에서 "일반" 선택 시 조회 결과 없음 (테이블에 'EMPLOYEE'가 없기 때문) -> 아무 권한 없는 직원 조회로 수정
- 정렬 조건 선택하지 않았을 때 기본 정렬 조건 수정 (사원ID -> 사번)
- work: 불필요한 주석 삭제

✅ 리뷰 요청 사항

⭐ 관련 이슈
#34 
