### PR TITLE
fix: 본인 출퇴근 내역 조회 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/controller/WorkQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/controller/WorkQueryController.java
@@ -26,7 +26,7 @@ public class WorkQueryController {
 
     @GetMapping("/me")
     @Operation(summary = "출퇴근 조회", description = "사원이 자신의 출퇴근 내역을 조회합니다.")
-    public ResponseEntity<ApiResponse<WorkListResponse>> getMyWorks(
+    public ResponseEntity<ApiResponse<MyWorkListResponse>> getMyWorks(
             @AuthenticationPrincipal UserDetails userDetails, @ModelAttribute WorkSearchRequest workSearchRequest
             ) {
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/MyWorkDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/MyWorkDTO.java
@@ -1,0 +1,48 @@
+package com.dao.momentum.work.query.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "근무 기록 DTO")
+public class MyWorkDTO {
+    @Schema(description = "근무 기록 ID", example = "1")
+    private long workId;
+
+    @Schema(description = "사원 ID", example = "1")
+    private long empId;
+
+    @Schema(description = "사번", example = "20250001")
+    private String empNo;
+
+    @Schema(description = "사원 이름", example = "홍길동")
+    private String empName;
+
+    @Schema(description = "근무 유형 ID", example = "3")
+    private int typeId;
+
+    @Schema(description = "근무 유형 이름", example = "VACATION")
+    private String typeName;
+
+    private String childTypeName;
+
+    @Schema(description = "휴가 유형 ID", example = "1")
+    private Integer vacationTypeId;
+
+    @Schema(description = "휴가 유형", example = "DAYOFF")
+    private String vacationType;
+
+    @Schema(description = "시작 일시")
+    private LocalDateTime startAt;
+
+    @Schema(description = "종료 일시")
+    private LocalDateTime endAt;
+
+    @Schema(description = "정상 근무 여부")
+    private IsNormalWork isNormalWork;
+
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/MyWorkListResponse.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/dto/response/MyWorkListResponse.java
@@ -1,0 +1,19 @@
+package com.dao.momentum.work.query.dto.response;
+
+import com.dao.momentum.common.dto.Pagination;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "근무 내역 응답 객체")
+public class MyWorkListResponse {
+    @Schema(description = "근무 내역")
+    private List<MyWorkDTO> works;
+
+    @Schema(description = "페이지네이션 정보")
+    private Pagination pagination;
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/mapper/WorkMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/mapper/WorkMapper.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Mapper
 public interface WorkMapper {
-    List<WorkDTO> getMyWorks(WorkSearchDTO request, long empId);
+    List<MyWorkDTO> getMyWorks(WorkSearchDTO request, long empId);
 
     List<WorkDTO> getWorks(@Param("request") AdminWorkSearchDTO request);
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/query/service/WorkQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/query/service/WorkQueryService.java
@@ -27,14 +27,14 @@ public class WorkQueryService {
     private final HolidayQueryService holidayQueryService;
 
     @Transactional(readOnly = true)
-    public WorkListResponse getMyWorks(UserDetails userDetails, WorkSearchRequest workSearchRequest) {
+    public MyWorkListResponse getMyWorks(UserDetails userDetails, WorkSearchRequest workSearchRequest) {
         long empId = Long.parseLong(userDetails.getUsername());
 
         WorkSearchDTO workSearchDTO = WorkSearchDTO.fromRequest(workSearchRequest);
 
-        List<WorkDTO> works = workMapper.getMyWorks(workSearchDTO, empId);
+        List<MyWorkDTO> works = workMapper.getMyWorks(workSearchDTO, empId);
 
-        return WorkListResponse.builder()
+        return MyWorkListResponse.builder()
                 .works(works)
                 .pagination(null)
                 .build();

--- a/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/work/WorkMapper.xml
@@ -3,14 +3,15 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.dao.momentum.work.query.mapper.WorkMapper">
-    <select id="getMyWorks" resultType="com.dao.momentum.work.query.dto.response.WorkDTO">
+    <select id="getMyWorks" resultType="com.dao.momentum.work.query.dto.response.MyWorkDTO">
         SELECT
             work.work_id,
             work.emp_id,
             emp.emp_no,
             emp.name AS empName,
             work.type_id,
-            wt.type_name,
+            COALESCE(pwt.type_name, cwt.type_name) AS typeName,
+            cwt.type_name AS childTypeName,
             work.vacation_type_id,
             vt.vacation_type AS vacationType,
             work.start_at,
@@ -18,7 +19,8 @@
             work.is_normal_work
         FROM work AS work
         JOIN employee AS emp ON work.emp_id = emp.emp_id
-        JOIN work_type AS wt ON work.type_id = wt.type_id
+        JOIN work_type AS cwt ON work.type_id = cwt.type_id
+        LEFT JOIN work_type AS pwt ON cwt.parent_type_id = pwt.type_id
         LEFT JOIN vacation_type AS vt ON work.vacation_type_id = vt.vacation_type_id
         WHERE work.emp_id = #{empId}
         <if test="request.rangeStartDate != null">

--- a/momentum-dao-be/src/test/java/com/dao/momentum/work/query/service/WorkQueryServiceTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/work/query/service/WorkQueryServiceTest.java
@@ -4,6 +4,8 @@ import com.dao.momentum.work.query.dto.request.AdminWorkSearchDTO;
 import com.dao.momentum.work.query.dto.request.AdminWorkSearchRequest;
 import com.dao.momentum.work.query.dto.request.WorkSearchDTO;
 import com.dao.momentum.work.query.dto.request.WorkSearchRequest;
+import com.dao.momentum.work.query.dto.response.MyWorkDTO;
+import com.dao.momentum.work.query.dto.response.MyWorkListResponse;
 import com.dao.momentum.work.query.dto.response.WorkDTO;
 import com.dao.momentum.work.query.dto.response.WorkListResponse;
 import com.dao.momentum.work.query.mapper.WorkMapper;
@@ -46,13 +48,13 @@ class WorkQueryServiceTest {
                 .rangeEndDate(LocalDate.of(2024, 1, 10))
                 .build();
 
-        List<WorkDTO> mockWorks = List.of(
-                WorkDTO.builder().workId(1L).empId(123L).build()
+        List<MyWorkDTO> mockWorks = List.of(
+                MyWorkDTO.builder().workId(1L).empId(123L).build()
         );
         when(workMapper.getMyWorks(any(WorkSearchDTO.class), eq(123L))).thenReturn(mockWorks);
 
         // when
-        WorkListResponse response = workQueryService.getMyWorks(userDetails, request);
+        MyWorkListResponse response = workQueryService.getMyWorks(userDetails, request);
 
         // then
         assertNotNull(response);


### PR DESCRIPTION
closes #000

---

📌 개요
- 본인 출퇴근 내역 조회(캘린더용) 기능이 작동하지 않아 수정
  - 관리자 출퇴근 내역 조회와 동일한 DTO를 공유하여 작성했으나, 해당 DTO의 수정 사항을 반영하지 않은 것이 원인
  - 본인 출퇴근 조회용 DTO를 분리하는 방향으로 수정
  - empId 등 일부 필드는 필요 없을 것으로 보임 (시간 남으면 수정 예정)

🔨 주요 변경 사항
- MyWorkDTO, MyWorkListResponse 생성, 쿼리 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#11 
