### PR TITLE
fix : 첨부 파일 관련된 부분에 name 속성 추가

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
@@ -84,13 +84,21 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
         // 3.첨부파일 S3 업로드 및 DB 저장
         List<AttachmentRequest> attachments = approveRequest.getAttachments();
 
+        // 영수증 결재에는 반드시 첨부파일이 있어야 함
+        if (approveType == ApproveType.RECEIPT) {
+            if (attachments == null || attachments.isEmpty()) {
+                throw new ApproveException(ErrorCode.RECEIPT_IMAGE_REQUIRED);
+            }
+        }
+
         if (attachments != null && !attachments.isEmpty()) {
             for (AttachmentRequest attachment : attachments) {
                 File file = File.builder()
                         .announcementId(null)
                         .approveId(approveId)
                         .contractId(null)
-                        .s3Key(attachment.getS3Key()) // 이미 S3 업로드된 URL
+                        .name(attachment.getName())
+                        .s3Key(attachment.getS3Key())
                         .type(attachment.getType())
                         .build();
                 fileRepository.save(file);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveFileDTO.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 public class ApproveFileDTO {
 
+    private String name;
     private String s3Key;
     private String type;
 

--- a/momentum-dao-be/src/main/resources/mappers/approve/AdminApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/AdminApproveMapper.xml
@@ -91,13 +91,15 @@
             SELECT dept_id FROM dept_tree
             )
         </if>
+
         <!-- 완료 날짜를 기준으로 정렬 -->
         ORDER BY
         <choose>
             <when test="req.sort == 'asc'">a.complete_at ASC</when>
             <when test="req.sort == 'desc'">a.complete_at DESC</when>
-            <otherwise>a.complete_at DESC</otherwise>
+            <otherwise>a.complete_at ASC</otherwise>
         </choose>
+        , a.approve_id
 
         LIMIT #{pageRequest.limit} OFFSET #{pageRequest.offset}
     </select>

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -27,7 +27,7 @@
     <!-- 결재 내역 파일 조회 -->
     <select id="getApproveFiles" resultType="com.dao.momentum.approve.query.dto.ApproveFileDTO">
         SELECT
-            s3_key, type
+            name, s3_key, type
         FROM file
         WHERE approve_id = #{approveId}
     </select>

--- a/momentum-dao-be/src/main/resources/mappers/approve/DraftApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/DraftApproveMapper.xml
@@ -60,13 +60,14 @@
             AND a.create_at &lt; #{req.endDate}
         </if>
 
-        <!-- 완료 날짜를 기준으로 정렬 -->
         ORDER BY
+        <!-- 완료 날짜를 기준으로 정렬 -->
         <choose>
             <when test="req.sort == 'asc'">a.complete_at ASC</when>
             <when test="req.sort == 'desc'">a.complete_at DESC</when>
-            <otherwise>a.complete_at DESC</otherwise>
+            <otherwise>a.complete_at ASC</otherwise>
         </choose>
+        , a.approve_id
 
         LIMIT #{pageRequest.limit} OFFSET #{pageRequest.offset}
     </select>

--- a/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
@@ -93,13 +93,14 @@
             )
         </if>
 
-        <!-- 완료 날짜를 기준으로 정렬 -->
         ORDER BY
+        <!-- 완료 날짜를 기준으로 정렬 -->
         <choose>
             <when test="req.sort == 'asc'">a.complete_at ASC</when>
             <when test="req.sort == 'desc'">a.complete_at DESC</when>
-            <otherwise>a.complete_at DESC</otherwise>
+            <otherwise>a.complete_at ASC</otherwise>
         </choose>
+        , a.approve_id
 
         LIMIT #{pageRequest.limit} OFFSET #{pageRequest.offset}
     </select>


### PR DESCRIPTION
closes #000

---

📌 개요
첨부 파일 관련된 부분에 name 속성 추가 및 order 변경

🔨 주요 변경 사항
- 상세 조회 시 첨부 파일 이름을 함께 조회할 수 있게 수정 
- `ApproveFileDTO`에 name 필드 추가
- 목록 조회 시 상태가 `대기`인 결재 문서가 먼저 목록에 노출될 수 있게 수정 
- 결재 문서 작성 시 name도 함께 추가할 수 있도록 수정 

✅ 리뷰 요청 사항

⭐ 관련 이슈
#3 #6 #7 #8 #9 