### PR TITLE
feat : 휴가 결재 시 사원 테이블에 휴가 수와 연차 시간 반영하는 로직 추가

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/aggregate/Employee.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/employee/command/domain/aggregate/Employee.java
@@ -95,6 +95,22 @@ public class Employee {
         this.updatedAt = LocalDateTime.now();
     }
 
+    /*
+    * 연차 시간을 수정하는 메소드
+    * */
+    public void updateRemainingDayOff(int remainingDayoffHours) {
+        this.remainingDayoffHours = remainingDayoffHours;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /*
+    * 리프레시 휴가 일수를 수정하는 메소드
+    * */
+    public void updateRemainingRefreshDay(int remainingRefreshDays) {
+        this.remainingRefreshDays = remainingRefreshDays;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public void fromUpdateMyInfo(MyInfoUpdateRequest request) {
         String name = request.getName();
         Gender gender = request.getGender();


### PR DESCRIPTION
closes #9

---

📌 개요
휴가 결재 시 사원 테이블에 휴가 수와 연차 시간 반영하는 로직 추가

🔨 주요 변경 사항
- 휴가 결재가 승인된 경우 : WorkApplyCommandService`
   - 사원의 연반차 시간 차감하는 로직 추가
   - 사원의 리프레시 휴가 차감하는 로직 추가
- 휴가 결재가 승인된 이후 취소 된 경우 : `ApprovalCancelCommandService`
   - 사원의 연반차 시간을 다시 복구하는 로직 추가
   - 사원의 리프레시 휴가를 다시 복구하는 로직 추가
- 좀 더 알아보기 쉽게 주석 추가 및 수정

✅ 리뷰 요청 사항
로직 점검 

⭐ 관련 이슈
#9 
