### PR TITLE
refactor : 초과 근무 종류를 확인하는 메소드 위치 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/OvertimeDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/approveTypeDTO/OvertimeDTO.java
@@ -23,25 +23,4 @@ public class OvertimeDTO {
 
     private List<String> workTypes = new ArrayList<>();
 
-    public void classifyWorkTypes() {
-        Set<String> types = new HashSet<>();
-
-        LocalDateTime cursor = startAt;
-        while (cursor.isBefore(endAt)) {
-            DayOfWeek day = cursor.getDayOfWeek();
-            int hour = cursor.getHour();
-
-            if (day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY) {
-                types.add("HOLIDAY");
-            } else if (hour >= 22 || hour < 6) {
-                types.add("NIGHT");
-            } else if (hour >= 18) {
-                types.add("OVERTIME");
-            }
-
-            cursor = cursor.plusMinutes(1);
-        }
-
-        this.workTypes = new ArrayList<>(types);
-    }
 }


### PR DESCRIPTION
closes #9

---

📌 개요
초과 근무 확인 메소드 위치 수정 

🔨 주요 변경 사항
- 초과 근무를 확인하는 메소드를 `OvertimeDTO`에서 `ApproveQueryServiceImpl`로 위치 수정
   (책임 분리, DTO는 데이터를 가져오는 것만 수행)
- `ApproveQueryServiceImpl`에서 나의 리더를 찾는 로직 위치 수정 및 주석 추가

✅ 리뷰 요청 사항

⭐ 관련 이슈
#9
