### PR TITLE
fix : 결재 문서 작성 시 휴가 관련 반영 사항 반영

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
@@ -139,7 +139,7 @@ public class ApprovalDecisionCommandServiceImpl implements ApprovalDecisionComma
         approvalAssignee.updateApproveLineListStatus(APPROVED);
 
         // 2. 승인 사유가 있다면 승인 사유 넣기
-        if(!reason.isEmpty()) {
+        if (reason != null && !reason.isEmpty()) {
             approvalAssignee.updateReason(reason);
         }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandServiceImpl.java
@@ -50,9 +50,13 @@ public class ApproveCommandServiceImpl implements ApproveCommandService{
         String title = approveRequest.getApproveTitle();
         JsonNode form = approveRequest.getFormDetail();
 
+        log.info("부모 결재 Id : {} ", parentApproveId);
         log.info("결재 종류 : {}", approveType);
         log.info("결재 문제 제목 : {}", title);
         log.info("결재 문서 내용 : {}", form);
+        log.info("결재선 목록 : {}", approveRequest.getApproveLineLists());
+        log.info("참조자 목록 : {}", approveRequest.getRefRequests());
+        log.info("첨부 파일 : {}", approveRequest.getAttachments());
 
         // 취소 요청인 경우에는 parentApproveId가 있어야 함
         if(approveType == ApproveType.CANCEL) {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/VacationFormStrategy.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/strategy/form/VacationFormStrategy.java
@@ -2,34 +2,62 @@ package com.dao.momentum.approve.command.application.service.strategy.form;
 
 import com.dao.momentum.approve.command.application.dto.request.approveType.VacationRequest;
 import com.dao.momentum.approve.command.application.service.strategy.FormDetailStrategy;
+import com.dao.momentum.approve.command.application.validator.VacationCommandValidator;
+import com.dao.momentum.approve.command.domain.aggregate.Approve;
+import com.dao.momentum.approve.command.domain.repository.ApproveRepository;
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.organization.employee.command.domain.repository.EmployeeRepository;
 import com.dao.momentum.work.command.domain.aggregate.Vacation;
 import com.dao.momentum.work.command.domain.repository.VacationRepository;
+import com.dao.momentum.work.command.domain.repository.VacationTypeRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class VacationFormStrategy implements FormDetailStrategy {
 
     private final ObjectMapper objectMapper;
     private final VacationRepository approveProposalRepository;
+    private final VacationTypeRepository vacationTypeRepository;
+    private final EmployeeRepository employeeRepository;
+    private final ApproveRepository approveRepository;
+    private final VacationCommandValidator vacationCommandValidator;
 
+    @Override
     public void saveDetail(JsonNode form, Long approveId) {
-        // VacationRequest 로 변환하기
+        // 1. VacationRequest 로 변환하기
         VacationRequest detail = objectMapper.convertValue(
                 form, VacationRequest.class
         );
 
-        // Vacation 만들기
+        // 2. 연반차, 리프레시 휴가인 경우 정해진 시간을 초과하지 못하게 설정
+        Approve approve = approveRepository.getApproveByApproveId(approveId)
+                .orElseThrow(() -> new ApproveException(ErrorCode.NOT_EXIST_APPROVE));
+
+        Long empId = approve.getEmpId();
+        int vacationTypeId = detail.getVacationTypeId();
+        LocalDate startDate = detail.getStartDate();
+        LocalDate endDate = detail.getEndDate();
+
+        vacationCommandValidator.validateVacationLimit(empId, vacationTypeId, startDate, endDate);
+
+        // 3. Vacation 만들기
         Vacation vacation = Vacation.builder()
                 .approveId(approveId)
-                .vacationTypeId(detail.getVacationTypeId())
-                .startDate(detail.getStartDate())
-                .endDate(detail.getEndDate())
+                .vacationTypeId(vacationTypeId)
+                .startDate(startDate)
+                .endDate(endDate)
                 .reason(detail.getReason())
                 .build();
+
         // 저장하기
         approveProposalRepository.save(vacation);
     }
@@ -47,4 +75,5 @@ public class VacationFormStrategy implements FormDetailStrategy {
                 vacation.getReason()
         );
     }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/validator/VacationCommandValidator.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/validator/VacationCommandValidator.java
@@ -1,0 +1,67 @@
+package com.dao.momentum.approve.command.application.validator;
+
+import com.dao.momentum.approve.exception.ApproveException;
+import com.dao.momentum.common.exception.ErrorCode;
+import com.dao.momentum.organization.employee.command.domain.aggregate.Employee;
+import com.dao.momentum.organization.employee.command.domain.repository.EmployeeRepository;
+import com.dao.momentum.organization.employee.exception.EmployeeException;
+import com.dao.momentum.work.command.application.validator.WorkCreateValidator;
+import com.dao.momentum.work.command.domain.aggregate.VacationType;
+import com.dao.momentum.work.command.domain.aggregate.VacationTypeEnum;
+import com.dao.momentum.work.command.domain.repository.VacationTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+/* 방학과 관련된 유효성 검사를 위한 클래스 */
+@Component
+@RequiredArgsConstructor
+public class VacationCommandValidator {
+
+    private final WorkCreateValidator workCreateValidator;
+    private final VacationTypeRepository vacationTypeRepository;
+    private final EmployeeRepository employeeRepository;
+
+    /* 연차, 반차, 리프레시 휴가는 지정된 날만 사용할 수 있게 설정하기 위해 하는 검사*/
+    public void validateVacationLimit(
+            Long empId, int vacationTypeId, LocalDate startDate, LocalDate endDate
+    ) {
+        VacationType vacationType =
+                vacationTypeRepository.getVacationTypeByVacationTypeId(vacationTypeId);
+
+        VacationTypeEnum vacationTypeEnum = vacationType.getVacationType();
+
+        Employee employee = employeeRepository.findByEmpId(empId)
+                .orElseThrow(() -> new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND));
+
+        int dayOff = employee.getRemainingDayoffHours();
+        int refresh = employee.getRemainingRefreshDays();
+
+        if (vacationTypeEnum == VacationTypeEnum.PM_HALF_DAYOFF ||
+                vacationTypeEnum == VacationTypeEnum.AM_HALF_DAYOFF) {
+            if (dayOff < 4) {
+                throw new ApproveException(ErrorCode.INSUFFICIENT_HALF_DAY_OFF);
+            }
+        } else if (vacationTypeEnum == VacationTypeEnum.DAYOFF) {
+            int workingDays = calculateWorkingDays(startDate, endDate);
+            int requiredHours = workingDays * 8;
+            if (dayOff < requiredHours) {
+                throw new ApproveException(ErrorCode.INSUFFICIENT_DAY_OFF);
+            }
+        } else if (vacationTypeEnum == VacationTypeEnum.REFRESH) {
+            int workingDays = calculateWorkingDays(startDate, endDate);
+            if (refresh < workingDays) {
+                throw new ApproveException(ErrorCode.INSUFFICIENT_REFRESH);
+            }
+        }
+    }
+
+    /* 휴가 일수를 계산해주는 메소드 */
+    public int calculateWorkingDays(LocalDate start, LocalDate end) {
+        return (int) Stream.iterate(start, date -> !date.isAfter(end), date -> date.plusDays(1))
+                .filter(date -> !workCreateValidator.isHoliday(date))
+                .count();
+    }
+}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
@@ -23,22 +23,26 @@ public interface ApproveLineRepository extends JpaRepository<ApproveLine, Long> 
     List<ApproveLine> getApproveLinesBeforeOrder(Long approveId, int currentOrder);
 
     /* 다음 결재선 찾기 */
-    @Query("""
-       SELECT al
-       FROM ApproveLine al
-       WHERE al.approveId = :approveId
-         AND al.approveLineOrder > :currentOrder
-       ORDER BY al.approveLineOrder ASC
-       """)
+    @Query(
+            value = """
+        SELECT *
+        FROM approve_line
+        WHERE approve_id = :approveId
+          AND approve_line_order > :currentOrder
+        ORDER BY approve_line_order ASC
+        LIMIT 1
+        """,
+            nativeQuery = true
+    )
     Optional<ApproveLine> findNextLine(Long approveId, int currentOrder);
 
     /* 결재 아이디로 해당 결재의 첫번째 결재선 찾기 */
-    @Query("""
-       SELECT al
-       FROM ApproveLine al
-       WHERE al.approveId = :approveId
-       ORDER BY al.approveLineOrder ASC
-       """)
+    @Query(value = """
+        SELECT * FROM approve_line
+        WHERE approve_id = :approveId
+        ORDER BY approve_line_order ASC
+        LIMIT 1
+    """, nativeQuery = true)
     Optional<ApproveLine> findFirstLine(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -89,6 +89,9 @@ public enum ErrorCode {
     APPROVAL_ALREADY_CANCELED("30020", "이미 취소된 결재는 다시 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
     PREVIOUS_APPROVAL_NOT_COMPLETED("30021", "이전 단계 결재가 완료 되지 않아 결재를 진행할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_EXIST_REF("30022", "존재하지 않는 참조 내역입니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_DAY_OFF("30023", "남은 연차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_HALF_DAY_OFF("30024", "남은 반차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_REFRESH("30025", "남은 리프레시 휴가 일수가 부족합니다.", HttpStatus.BAD_REQUEST),
 
     // 평가 오류 (40001 ~ 49999)
     // KPI 오류

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkApplyCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkApplyCommandService.java
@@ -210,8 +210,12 @@ public class WorkApplyCommandService {
                 .orElseThrow(() -> new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
         if(vacationTypeEnum == VacationTypeEnum.DAYOFF) {
-            employee.updateRemainingDayOff(employee.getRemainingDayoffHours() - 8); // 연차인 경우 휴가 날짜 만큼 차감
-        } else {
+            int dayOff = (int) Stream.iterate(startDate, date -> !date.isAfter(endDate), date -> date.plusDays(1))
+                    .filter(date -> !workCreateValidator.isHoliday(date))  // 휴일이 아닌 날만 필터링
+                    .count();
+
+            employee.updateRemainingDayOff(employee.getRemainingDayoffHours() - dayOff * 8); // 연차인 경우 휴가 날짜 만큼 차감
+        } else if(vacationTypeEnum == VacationTypeEnum.REFRESH) {
             int vacationDays = (int) Stream.iterate(startDate, date -> !date.isAfter(endDate), date -> date.plusDays(1))
                     .filter(date -> !workCreateValidator.isHoliday(date))  // 휴일이 아닌 날만 필터링
                     .count();


### PR DESCRIPTION
closes #9

---

📌 개요
결재 문서 작성 시 휴가 관련 반영 사항 반영

🔨 주요 변경 사항
- 휴가 관련 유효성 검사를 `VacationCommandValidator` 파일로 분리
- 휴가에서 리프레시 휴가인 경우 조건 추가하기
- 휴가에서 연반차, 리프레시 휴가는 현재 있는 시간을 초과할 수 없게 설정
- 승인 사유에서 `!reason.isEmpty()`인지만 검사하고 있어서 null이 아닌 경우까지 추가
-  log 내용 추가 (결재 작성시)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#9
