### PR TITLE
feat :  근속 지원 최종 계산 로직

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/calculator/RetentionScoreCalculator.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/calculator/RetentionScoreCalculator.java
@@ -4,5 +4,5 @@ import com.dao.momentum.organization.employee.command.domain.aggregate.Employee;
 import com.dao.momentum.retention.prospect.command.application.dto.request.RetentionSupportDto;
 
 public interface RetentionScoreCalculator {
-    RetentionSupportDto calculate(Employee employee);
+    RetentionSupportDto calculate(Integer year, Integer month, Employee employee);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/dto/request/RetentionSupportDto.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/dto/request/RetentionSupportDto.java
@@ -19,12 +19,12 @@ public record RetentionSupportDto(
         @Schema(description = "성장 만족도 (0~100)", example = "70")
         int growthLevel,
 
-        @Schema(description = "근속 연수", example = "3.5")
-        BigDecimal tenureLevel,
+        @Schema(description = "근속 만족도 (0~100)", example = "50")
+        int tenureLevel,
 
         @Schema(description = "워라밸 만족도 (0~100)", example = "90")
         int wlbLevel,
 
         @Schema(description = "최종 근속 전망 점수 (0~100)", example = "78")
-        int retentionScore
+        BigDecimal retentionScore
 ) {}

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/facade/RetentionForecastFacade.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/facade/RetentionForecastFacade.java
@@ -62,7 +62,7 @@ public class RetentionForecastFacade {
         // 근속 지원 정보 계산 및 저장
         List<RetentionSupport> supports = employees.stream()
                 .map(emp -> {
-                    var dto = calculator.calculate(emp);
+                    var dto = calculator.calculate(request.year(), request.month(), emp); // 계산할 때 기준 년도와 기준 달이 필요하기 때문에 파라미터로 넘김
                     return RetentionSupport.of(round.getRoundId(), emp.getEmpId(), dto);
                 })
                 .toList();


### PR DESCRIPTION
 #000
(모든 점수 계산 로직이 만들어진 다음 연결되면 그 때 close)

---

📌 개요
근속 지원 최종 계산 로직 작성 

🔨 주요 변경 사항
- `RetentionScoreCalculator` 에서 calculate 매개변수에 기준 연도(year)와 기준 달(month)추가 
- `RetentionSupportDto`
  - 근속 연수에서 근속 만족도로 수정 및 자료형을 int로 수정 (기존에는 계수였지만 현재는 점수 이기 때문)
  - 총점은 소수점 1자리까지 받아야 될 것 같다고 생각해 자료형을 `BigDecimal`로 수정 (이 부분은 추후에 다시 int로 변경 가능)
- `RetentionForecastFacade`에서 계산 시 기준 연도(year)와 기준 달(month)이 필요 하므로 해당 값을 같이 인자로  전달함
- `RetentionScoreCalculatorImpl`  
  - 각 항목별 메서드에 year와 month를 인자로 넘길 수 있도록 통일
  - 총 6개 항목(직무 만족도, 임금 및 복지, 상사 및 동료 관계, 경력 개발 기회, 근속 및 근태, 워라밸 및 초과근무)에 대해 각각 최대 점수(20점 또는 15점)를 기준으로 점수를 계산 메소드 작성
  - `calculate()` 메서드에서는 이 원점수들을 100점 만점 기준으로 환산하여 RetentionSupportDto에 담아 반환. 이 때, 항목의 최대 점수가 20점인 경우에는 점수 * 5, 15점인 경우에는 점수 * (20 / 3) 방식으로 변환하여 반영 (각 점수를 100점으로 생각해서 환산)
  - `weightedScore` 메소드에서 나이 보정 계수(ageCoefficient)를 반영한 최종 점수를 계산


✅ 리뷰 요청 사항
- 전체적인 점수 계산 로직 점검 

⭐ 관련 이슈
#369
