### PR TITLE
refactor : endpoint 변경 및 조회 관련 오류 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/RemainingVacationQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/RemainingVacationQueryController.java
@@ -8,13 +8,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/employees")
+@RequestMapping("/remaining")
 @Tag(name = "잔여 휴가 시간 조회", description ="잔여 휴가 시간 조회 API")
 @RequiredArgsConstructor
 public class RemainingVacationQueryController {
@@ -22,22 +23,26 @@ public class RemainingVacationQueryController {
     private final RemainingVacationQueryService remainingVacationQueryService;
 
     /* 잔여 연차 시간 조회 */
-    @GetMapping("/{empId}/dayoff")
+    @GetMapping("/dayoff")
     @Operation(summary = "잔여 연차 시간 조회", description ="사원의 잔여 연차 시간을 조회합니다.")
     public ResponseEntity<ApiResponse<DayoffResponse>> getRemainingDayoffs(
-            @PathVariable long empId
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
+        long empId = Long.parseLong(userDetails.getUsername());
+
         DayoffResponse response = remainingVacationQueryService.getRemainingDayoffs(empId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /* 잔여 리프레시 휴가 일수 조회*/
-    @GetMapping("/{empId}/refresh")
+    @GetMapping("/refresh")
     @Operation(summary = "잔여 리프레시 휴가 일수 조회", description ="사원의 잔여 리프레시 휴가 일수를 조회합니다.")
     public ResponseEntity<ApiResponse<RefreshResponse>> getRemainingRefreshs(
-            @PathVariable long empId
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
+        long empId = Long.parseLong(userDetails.getUsername());
+
         RefreshResponse response = remainingVacationQueryService.getRemainingRefreshs(empId);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -107,7 +107,9 @@ public class SecurityConfig {
     // 회원(로그인 사용자)만 접근 가능
     private void employeeEndpoints(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auths) {
         auths.requestMatchers(
-                "/employees/me"
+                "/employees/me",
+                "/remaining/refresh",
+                "/remaining/dayoff"
         ).authenticated();
 
 //        auths.requestMatchers(

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -140,7 +140,7 @@
             v.end_date,
             v.reason
         FROM vacation v
-        JOIN vacation_type vt ON v.vacation_id = vt.vacation_type_id
+        JOIN vacation_type vt ON v.vacation_type_id = vt.vacation_type_id
         WHERE approve_id = #{approveId}
     </select>
 


### PR DESCRIPTION
closes #000

---

📌 개요
 endpoint 변경 및 조회 관련 오류 수정

🔨 주요 변경 사항
- 결재 작성 시 조회되는 사원의 리프레시 휴가 수와 연차 수 조회 endpoints 변경 및 security에 해당 위치 설정
- 결재 상세 보기에서 휴가 종류가 이상하게 조회 되는 부분 해결 (`vacation_type_id`를 `vacation_id`로 쓰고 있었음)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#8 #9
