### PR TITLE
feat: 근속 지원 점수 계산 메서드 반영 

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/organization/contract/command/application/service/ContractRetentionService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/organization/contract/command/application/service/ContractRetentionService.java
@@ -34,7 +34,7 @@ public class ContractRetentionService {
      * @return 0 또는 음수(-13 ~ 0)의 페널티 점수
      */
     @Transactional(readOnly = true)
-    public int getScoreBySalaryIncrements(long empId, LocalDate targetDate) {
+    public int calculateScoreBySalaryIncrements(long empId, LocalDate targetDate) {
         Employee employee = employeeRepository.findByEmpId(empId)
                 .orElseThrow(() -> new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND));
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/calculator/RetentionScoreCalculatorImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/retention/prospect/command/application/calculator/RetentionScoreCalculatorImpl.java
@@ -76,7 +76,7 @@ public class RetentionScoreCalculatorImpl implements RetentionScoreCalculator {
     private int calculateCompLevel(Integer year, Integer month, Employee emp) {
         int compScore = 20;
         long empId = emp.getEmpId();
-        LocalDate targetDate = LocalDate.of(year, month, 1);
+        LocalDate targetDate = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1); // 대상 달(과거 날짜)의 마지막 날
 
         // 1. 연봉 (최대 -13점)
         // 0 또는 감점을 적용한 음수이므로 더해준다. (예시: 20 + (-5) = 15)
@@ -91,7 +91,7 @@ public class RetentionScoreCalculatorImpl implements RetentionScoreCalculator {
     private int calculateRelationLevel(Integer year, Integer month, Employee emp) {
         int relationScore = 15;
         long empId = emp.getEmpId();
-        LocalDate targetDate = LocalDate.of(year, month, 1);
+        LocalDate targetDate = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1);
 
         // 1. 다면 평가
 
@@ -106,9 +106,10 @@ public class RetentionScoreCalculatorImpl implements RetentionScoreCalculator {
     /* 경력 개발 기회 계산 메소드 */
     private int calculateGrowthLevel(Integer year, Integer month, Employee emp) {
         int growthScore = 15;
+        LocalDate targetDate = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1);
 
         // 1. 승진 정체 (최대 -7점)
-        growthScore += appointRetentionService.calculateScoreByPromotion(emp.getEmpId(), LocalDate.of(year, month, 1));
+        growthScore += appointRetentionService.calculateScoreByPromotion(emp.getEmpId(), targetDate);
 
         // 2. KPI 미달성
 
@@ -120,15 +121,15 @@ public class RetentionScoreCalculatorImpl implements RetentionScoreCalculator {
     /* 근속 연수, 근태 계산 메소드 */
     private int calculateTenureLevel(Integer year, Integer month, Employee emp) {
         double tenureScore = 15;
-        LocalDate targetDate = LocalDate.of(year, month, 1);
+        LocalDate targetDate = LocalDate.of(year, month, 1).plusMonths(1);
         long empId = emp.getEmpId();
 
         // 1. 근속 연수 (최대 -9점)
-        tenureScore += workRetentionService.calculateScoreByWorkedMonths(empId, targetDate);
+        tenureScore += workRetentionService.calculateScoreByWorkedMonths(empId, targetDate.minusDays(1));
 
         // 2. 근태 이력 (최대 -6점)
-        // 메서드 로직 상 1개월 뒤가 필요 (6월 근속 지원 기능이라면 인자로 7월 1일을 받아야함)
-        tenureScore += workRetentionService.calculateScoreByAbsenceAndLate(empId, targetDate.plusMonths(1));
+        // 메서드 로직 상 대상 달 다음달의 1일이 필요 (이 값을 변수 targetDate로 정의)
+        tenureScore += workRetentionService.calculateScoreByAbsenceAndLate(empId, targetDate);
 
         return clampScore((int) tenureScore, 15);
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkRetentionService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkRetentionService.java
@@ -32,7 +32,7 @@ public class WorkRetentionService {
     private final WorkCreateValidator workCreateValidator;
 
     // 최대 9점 감점
-    public double computeScoreByWorkedMonths(long empId, LocalDate targetDate) {
+    public double calculateScoreByWorkedMonths(long empId, LocalDate targetDate) {
         Employee emp = employeeRepository.findByEmpId(empId)
                 .orElseThrow(() -> new EmployeeException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
@@ -81,7 +81,7 @@ public class WorkRetentionService {
      *  - 거기서 4주 전 월요일을 periodStart 로 잡아
      * 해당 기간의 무단결근 및 지각 스코어를 계산
      */
-    public int computeAbsenceAndLate(long empId, LocalDate targetDate) {
+    public int calculateScoreByAbsenceAndLate(long empId, LocalDate targetDate) {
         // 기간 계산
         LocalDate periodEnd = targetDate.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
         LocalDate periodStart = periodEnd.minusWeeks(4).plusDays(1);
@@ -97,7 +97,7 @@ public class WorkRetentionService {
         long absenceCount = countAbsence(works, periodStart, periodEnd);
 
         // 최종 스코어
-        return Math.max(MIN_SCORE_BY_ATTENDANCE, calcAbsenceAndLateScore(absenceCount, lateCount));
+        return Math.max(MIN_SCORE_BY_ATTENDANCE, getPenaltyByAbsenceAndLate(absenceCount, lateCount));
     }
 
     /**
@@ -119,7 +119,7 @@ public class WorkRetentionService {
     }
 
     /** 무단결근당 -2점, 지각 3회당 -1점 */
-    private int calcAbsenceAndLateScore(long absenceCount, long lateCount) {
+    private int getPenaltyByAbsenceAndLate(long absenceCount, long lateCount) {
         int absenceWeight = -2;
         int lateWeight    = -1;
         int lateUnits     = (int)(lateCount / 3);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkRetentionService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/application/service/WorkRetentionService.java
@@ -40,7 +40,7 @@ public class WorkRetentionService {
 
         int workedMonths = calculateWorkedMonths(joinDate, targetDate);
 
-        return minusByWorkedMonths(workedMonths);
+        return getPenaltyByWorkedMonths(workedMonths);
     }
 
     public int calculateWorkedMonths(LocalDate joinDate, LocalDate targetDate) {
@@ -55,7 +55,7 @@ public class WorkRetentionService {
         return (int) monthsBetween;
     }
 
-    private double minusByWorkedMonths(int workedMonths) {
+    private double getPenaltyByWorkedMonths(int workedMonths) {
         if (workedMonths <= 11) {
             return -7.5;
         }


### PR DESCRIPTION
closes #000

---

📌 개요
- 근속 지원 점수 계산 메서드 반영

🔨 주요 변경 사항
- 연봉 상승, 발령, 승진, 근속 연수, 근태 메서드 `RetentionScoreCalculatorImpl `에 반영
- 메서드명 통일성 있게 수정

✅ 리뷰 요청 사항
- 감점하는 점수에 소수점이 포함된 경우가 있어, double 혹은 BigDecimal로 자료형 수정 필요할 듯 (예시 하단 이미지)
<img width="959" height="378" alt="image" src="https://github.com/user-attachments/assets/9b71974d-2e6e-4dff-af62-4ff52c276c4f" />


⭐ 관련 이슈
#369 
