### PR TITLE
fix : 조회 가능 한 결재만 조회 할 수 있게 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/controller/ApproveQueryController.java
@@ -67,11 +67,13 @@ public class ApproveQueryController {
     @GetMapping("/documents/{documentId}")
     @Operation(summary = "결재 문서 상세 조회", description = "결재 문서를 상세 조회합니다.")
     public ResponseEntity<ApiResponse<ApproveDetailResponse>> getDraftApprovals(
-            @PathVariable Long documentId
+            @PathVariable Long documentId,
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
 
         ApproveDetailResponse approveDetailResponse
-                = approveQueryService.getApproveDetail(documentId);
+                = approveQueryService.getApproveDetail(documentId, empId);
 
         return ResponseEntity.ok(ApiResponse.success(approveDetailResponse));
     }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveDetailMapper.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/mapper/ApproveDetailMapper.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface ApproveDetailMapper {
 
     /* 모든 폼에서 공통적으로 조회되는 내용 */
-    Optional<ApproveDTO> getApproveDTO(Long approveId);
+    Optional<ApproveDTO> getApproveDTO(Long approveId, Long empId, boolean isAdmin);
 
     List<ApproveFileDTO> getApproveFiles(Long approveId);
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/service/ApproveQueryService.java
@@ -25,7 +25,7 @@ public interface ApproveQueryService {
     );
 
     /* 결재 상세 조회 메서드 */
-    ApproveDetailResponse getApproveDetail(Long approveId);
+    ApproveDetailResponse getApproveDetail(Long approveId, Long empId);
 
 
     /* 사원의 팀장 조회 메서드 */

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -16,12 +16,37 @@
             a.create_at,
             a.complete_at,
             e.name AS employee_name,
-            d.name AS department_name
+            d.name AS department_name,
+
+            CASE
+                WHEN a.emp_id = #{empId} THEN 'WRITER'
+                WHEN ali.emp_id IS NOT NULL THEN 'APPROVAL'
+                WHEN ar.emp_id IS NOT NULL THEN 'REFERENCE'
+                WHEN #{isAdmin} = TRUE THEN 'MASTER'
+            ELSE NULL
+            END AS received_type
+
         FROM approve a
         JOIN employee e ON a.emp_id = e.emp_id
         JOIN department d ON e.dept_id = d.dept_id
         JOIN status s ON a.status_id = s.status_id
+
+        LEFT JOIN approve_line al ON al.approve_id = a.approve_id
+        LEFT JOIN approve_line_list ali
+        ON ali.approve_line_id = al.approve_line_id
+        AND ali.emp_id = #{empId}
+
+        LEFT JOIN approve_ref ar
+        ON ar.approve_id = a.approve_id
+        AND ar.emp_id = #{empId}
+
         WHERE a.approve_id = #{approveId}
+        AND (
+            a.emp_id = #{empId}
+            OR ali.emp_id IS NOT NULL
+            OR ar.emp_id IS NOT NULL
+            OR #{isAdmin} = TRUE
+        )
     </select>
 
     <!-- 결재 내역 파일 조회 -->

--- a/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ReceivedApproveMapper.xml
@@ -17,10 +17,10 @@
             e.name AS employee_name,
             d.name AS department_name,
             CASE
-            WHEN ali.emp_id IS NOT NULL THEN 'APPROVAL'
-            WHEN ar.emp_id IS NOT NULL THEN 'REFERENCE'
+                WHEN ali.emp_id IS NOT NULL THEN 'APPROVAL'
+                WHEN ar.emp_id IS NOT NULL THEN 'REFERENCE'
             ELSE NULL
-            END AS received_type
+        END AS received_type
 
         FROM approve a
         LEFT JOIN approve aa ON a.parent_approve_id = aa.approve_id
@@ -85,17 +85,17 @@
         <!-- 부서 -->
         <if test="req.deptId != null">
             AND e.dept_id IN (
-                WITH RECURSIVE dept_tree AS (
-                    SELECT dept_id
-                    FROM department
-                    WHERE dept_id = #{req.deptId}
-                    AND is_deleted = 'N'
-                        UNION ALL
-                    SELECT d.dept_id
-                    FROM department d
-                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
-                    WHERE d.is_deleted = 'N'
-                )
+            WITH RECURSIVE dept_tree AS (
+            SELECT dept_id
+            FROM department
+            WHERE dept_id = #{req.deptId}
+            AND is_deleted = 'N'
+            UNION ALL
+            SELECT d.dept_id
+            FROM department d
+            INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+            WHERE d.is_deleted = 'N'
+            )
             SELECT dept_id FROM dept_tree
             )
         </if>
@@ -120,10 +120,11 @@
         JOIN employee e ON a.emp_id = e.emp_id
         JOIN department d ON e.dept_id = d.dept_id
         JOIN status s ON a.status_id = s.status_id
-        JOIN approve_line al ON al.approve_id = a.approve_id
-        JOIN approve_line_list ali ON al.approve_line_id = ali.approve_line_id
+        LEFT JOIN approve_line al ON al.approve_id = a.approve_id
+        LEFT JOIN approve_line_list ali ON al.approve_line_id = ali.approve_line_id AND ali.emp_id = #{empId}
+        LEFT JOIN approve_ref ar ON a.approve_id = ar.approve_id AND ar.emp_id = #{empId}
 
-        WHERE ali.emp_id = #{empId}
+        WHERE (ali.emp_id IS NOT NULL OR ar.emp_id IS NOT NULL)
 
         <if test="req.tab != 'ALL'">
             <if test="req.tab == 'ATTENDANCE'">
@@ -171,17 +172,17 @@
 
         <if test="req.deptId != null">
             AND e.dept_id IN (
-                WITH RECURSIVE dept_tree AS (
-                    SELECT dept_id
-                    FROM department
-                    WHERE dept_id = #{req.deptId}
-                    AND is_deleted = 'N'
-                        UNION ALL
-                    SELECT d.dept_id
-                    FROM department d
-                    INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
-                    WHERE d.is_deleted = 'N'
-                )
+            WITH RECURSIVE dept_tree AS (
+            SELECT dept_id
+            FROM department
+            WHERE dept_id = #{req.deptId}
+            AND is_deleted = 'N'
+            UNION ALL
+            SELECT d.dept_id
+            FROM department d
+            INNER JOIN dept_tree dt ON d.parent_dept_id = dt.dept_id
+            WHERE d.is_deleted = 'N'
+            )
             SELECT dept_id FROM dept_tree
             )
         </if>
@@ -190,9 +191,9 @@
     <!-- 존재하는 회원인지 확인하기 위한 코드 -->
     <select id="existsByEmpId" resultType="boolean">
         SELECT CASE WHEN EXISTS (
-            SELECT 1
-            FROM employee
-            WHERE emp_id = #{empId}
+        SELECT 1
+        FROM employee
+        WHERE emp_id = #{empId}
         ) THEN TRUE ELSE FALSE END
     </select>
 

--- a/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
+++ b/momentum-dao-be/src/test/java/com/dao/momentum/approve/query/service/ApproveQueryServiceImplTest.java
@@ -3,7 +3,6 @@ package com.dao.momentum.approve.query.service;
 import com.dao.momentum.approve.command.domain.aggregate.ApproveType;
 import com.dao.momentum.approve.exception.NotExistTabException;
 import com.dao.momentum.approve.query.dto.*;
-import com.dao.momentum.approve.query.dto.approveTypeDTO.ApproveCancelDTO;
 import com.dao.momentum.approve.query.dto.approveTypeDTO.ApproveProposalDTO;
 import com.dao.momentum.approve.query.dto.request.ApproveListRequest;
 import com.dao.momentum.approve.query.dto.request.DraftApproveListRequest;
@@ -16,6 +15,8 @@ import com.dao.momentum.approve.query.mapper.ApproveMapper;
 import com.dao.momentum.approve.query.mapper.ReceivedApproveMapper;
 import com.dao.momentum.approve.query.mapper.DraftApproveMapper;
 import com.dao.momentum.organization.employee.exception.EmployeeException;
+import com.dao.momentum.organization.employee.query.dto.response.EmployeeRoleDTO;
+import com.dao.momentum.organization.employee.query.mapper.UserRoleMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,9 @@ class ApproveQueryServiceImplTest {
 
     @Mock
     private ApproveMapper approveMapper;
+
+    @Mock
+    private UserRoleMapper userRoleMapper;
 
     @InjectMocks
     private ApproveQueryServiceImpl approveService;
@@ -161,7 +165,14 @@ class ApproveQueryServiceImplTest {
     @Test
     @DisplayName("결재 상세 조회 테스트")
     void testGetNormalApproveDetail() {
+        Long empId = 100L;
         Long approveId = 1L;
+
+        List<EmployeeRoleDTO> roles = List.of(
+                EmployeeRoleDTO.builder()
+                        .userRoleId(1)
+                        .build()
+        );
 
         ApproveDTO approveDTO = ApproveDTO.builder()
                 .approveId(1L)
@@ -195,13 +206,14 @@ class ApproveQueryServiceImplTest {
                 .content("결재 더미 데이터")
                 .build();
 
-        when(approveDetailMapper.getApproveDTO(approveId)).thenReturn(Optional.of(approveDTO));
+        when(userRoleMapper.getEmployeeRoles(empId)).thenReturn(roles);
+        when(approveDetailMapper.getApproveDTO(approveId, empId, true)).thenReturn(Optional.of(approveDTO));
         when(approveDetailMapper.getApproveLines(approveId)).thenReturn(lineList);
         when(approveDetailMapper.getApproveLineList(any())).thenReturn(lineListDetail);
         when(approveDetailMapper.getApproveRefs(approveId)).thenReturn(refList);
         when(approveDetailMapper.getProposalDetail(approveId)).thenReturn(Optional.of(formDetail));
 
-        ApproveDetailResponse result = approveService.getApproveDetail(approveId);
+        ApproveDetailResponse result = approveService.getApproveDetail(approveId, empId);
 
         assertNotNull(result);
         assertEquals(approveDTO, result.getApproveDTO());


### PR DESCRIPTION
closes #8

---

📌 개요
현재 어떤 사원이라도 결재 문서를 조회할 수 있어서, 
이를 막기 위해 조회 가능 한 결재만 조회 할 수 있게 수정

🔨 주요 변경 사항
- 사원 본인이 받은 문서(참조자 or 결재자), 작성한 문서인 경우에만 조회 가능 (controller, mapper, service 모두 수정)
- 마스터 관리자인 경우에는 모든 문서 상세 조회 가능하게 수정  (controller, mapper, service 모두 수정)
- 결재 상세 조회 테스트 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#8
