### PR TITLE
fix : 결재 문서 상세 조회 관련 에러 해결

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -92,6 +92,8 @@ public enum ErrorCode {
     INSUFFICIENT_DAY_OFF("30023", "남은 연차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_HALF_DAY_OFF("30024", "남은 반차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_REFRESH("30025", "남은 리프레시 휴가 일수가 부족합니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_START_APPROVAL("30026", "결재가 시작되어 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NO_DELETE_PERMISSION("30027", "삭제할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
 
     // 평가 오류 (40001 ~ 49999)
     // KPI 오류

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -20,10 +20,19 @@
 
             CASE
                 WHEN a.emp_id = #{empId} THEN 'WRITER'
-                WHEN ali.emp_id IS NOT NULL THEN 'APPROVAL'
-                WHEN ar.emp_id IS NOT NULL THEN 'REFERENCE'
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM approve_line al2
+                    JOIN approve_line_list ali2 ON al2.approve_line_id = ali2.approve_line_id
+                    WHERE al2.approve_id = a.approve_id AND ali2.emp_id = #{empId}
+                    ) THEN 'APPROVAL'
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM approve_ref ar2
+                    WHERE ar2.approve_id = a.approve_id AND ar2.emp_id = #{empId}
+                    ) THEN 'REFERENCE'
                 WHEN #{isAdmin} = TRUE THEN 'MASTER'
-            ELSE NULL
+                ELSE NULL
             END AS received_type
 
         FROM approve a
@@ -31,21 +40,21 @@
         JOIN department d ON e.dept_id = d.dept_id
         JOIN status s ON a.status_id = s.status_id
 
-        LEFT JOIN approve_line al ON al.approve_id = a.approve_id
-        LEFT JOIN approve_line_list ali
-        ON ali.approve_line_id = al.approve_line_id
-        AND ali.emp_id = #{empId}
-
-        LEFT JOIN approve_ref ar
-        ON ar.approve_id = a.approve_id
-        AND ar.emp_id = #{empId}
-
         WHERE a.approve_id = #{approveId}
         AND (
             a.emp_id = #{empId}
-            OR ali.emp_id IS NOT NULL
-            OR ar.emp_id IS NOT NULL
-            OR #{isAdmin} = TRUE
+            OR EXISTS (
+                SELECT 1
+                FROM approve_line al2
+                JOIN approve_line_list ali2 ON al2.approve_line_id = ali2.approve_line_id
+                WHERE al2.approve_id = a.approve_id AND ali2.emp_id = #{empId}
+            )
+        OR EXISTS (
+                SELECT 1
+                FROM approve_ref ar2
+                WHERE ar2.approve_id = a.approve_id AND ar2.emp_id = #{empId}
+            )
+        OR #{isAdmin} = TRUE
         )
     </select>
 


### PR DESCRIPTION
closes #8 

---

📌 개요
결재 문서 상세 조회 관련 에러 해결 (결재선이 여러 개 있는 경우 조회 되지 않는 에러)

🔨 주요 변경 사항
- `ApproveDetailMapper`에서 left 조인 제거 후 case, when을 이용해 로직 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#8
