### PR TITLE
feat : 결재 문서 회수 기능 구현

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
@@ -78,4 +78,17 @@ public class ApproveCommandController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @DeleteMapping("/documents/{documentId}")
+    @Operation(summary = "결재 회수", description = "결재 내역을 회수 합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteApproval(
+            @PathVariable Long documentId ,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        approveCommandService.deleteApproval(documentId, empId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApprovalDecisionCommandServiceImpl.java
@@ -191,7 +191,7 @@ public class ApprovalDecisionCommandServiceImpl implements ApprovalDecisionComma
 
     /* 마지막 결재선이 승인되었다면 결재를 승인으로 처리*/
     private void updateApproveStatusIfFinalApprovalLine(Approve approve) {
-        List<Integer> approveLines = approveLineRepository.getApproveLinesByApproveId(approve.getApproveId());
+        List<Integer> approveLines = approveLineRepository.getApproveLinesStatusByApproveId(approve.getApproveId());
 
         boolean allApproved = approveLines.stream()
                 .allMatch(statusId -> statusId == APPROVED);

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
@@ -10,4 +10,5 @@ public interface ApproveCommandService {
 
     void viewAsReference(Long approveId, Long empId);
 
+    void deleteApproval(Long approveId, Long empId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveCancelRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveCancelRepository.java
@@ -2,6 +2,8 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveCancel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,5 +12,10 @@ import java.util.Optional;
 public interface ApproveCancelRepository extends JpaRepository<ApproveCancel, Long> {
 
     Optional<ApproveCancel> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveCancel ac WHERE ac.approveId = :approveId")
+    void deleteApproveCancelByApproveId(Long approveId);
+
 }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineListRepository.java
@@ -2,6 +2,7 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveLineList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -22,5 +23,12 @@ public interface ApproveLineListRepository extends JpaRepository<ApproveLineList
 
     /* 결재선 아이디로 해당 결재선의 결재자 목록 가져오기 */
     List<ApproveLineList> findByApproveLineId(Long approveLineId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveLineList all WHERE all.approveLineId = :approveLineId")
+    void deleteApproveLineListByApproveLineId(Long approveLineId);
+
+    @Query("SELECT al.statusId FROM ApproveLineList al WHERE al.approveLineId IN :approveLineIds")
+    List<Integer> getAllStatusesByApproveLineIds(List<Long> approveLineIds);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveLineRepository.java
@@ -2,6 +2,7 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveLine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -16,7 +17,7 @@ public interface ApproveLineRepository extends JpaRepository<ApproveLine, Long> 
 
     /* 결재 아이디로 해당 결재에 속한 결재선의 상태 가져오기 */
     @Query("SELECT a.statusId FROM ApproveLine a WHERE a.approveId = :approveId")
-    List<Integer> getApproveLinesByApproveId(Long approveId);
+    List<Integer> getApproveLinesStatusByApproveId(Long approveId);
 
     /* 이전 결재선 찾기 */
     @Query("SELECT a FROM ApproveLine a WHERE a.approveId = :approveId AND a.approveLineOrder < :currentOrder")
@@ -44,5 +45,13 @@ public interface ApproveLineRepository extends JpaRepository<ApproveLine, Long> 
         LIMIT 1
     """, nativeQuery = true)
     Optional<ApproveLine> findFirstLine(Long approveId);
+
+    /* 결재 아이디로 해당 결재에 속한 결재선의 아이디 가져오기 */
+    @Query("SELECT a.id FROM ApproveLine a WHERE a.approveId = :approveId")
+    List<Long> getApproveLinesByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveLine al WHERE al.approveId = :approveId")
+    void deleteApproveLinesByApproveId(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveProposalRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveProposalRepository.java
@@ -2,6 +2,8 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveProposal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,5 +12,10 @@ import java.util.Optional;
 public interface ApproveProposalRepository extends JpaRepository<ApproveProposal, Long> {
 
     Optional<ApproveProposal> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveProposal ar WHERE ar.approveId = :approveId")
+    void deleteApproveProposalByApprovalId(Long approveId);
+
 }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveReceiptRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveReceiptRepository.java
@@ -2,6 +2,8 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveReceipt;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,5 +12,10 @@ import java.util.Optional;
 public interface ApproveReceiptRepository extends JpaRepository<ApproveReceipt, Long> {
 
     Optional<ApproveReceipt> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveReceipt ar WHERE ar.approveId = :approveId")
+    void deleteApproveReceiptByApprovalId(Long approveId);
+
 }
 

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRefRepository.java
@@ -2,6 +2,8 @@ package com.dao.momentum.approve.command.domain.repository;
 
 import com.dao.momentum.approve.command.domain.aggregate.ApproveRef;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,5 +12,9 @@ import java.util.Optional;
 public interface ApproveRefRepository extends JpaRepository<ApproveRef, Long> {
 
     Optional<ApproveRef> getApproveRefByApproveIdAndEmpId(Long approveId, Long empId);
+
+    @Modifying
+    @Query("DELETE FROM ApproveRef ar WHERE ar.approveId = :approveId")
+    void deleteApproveRefByApprovalId(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/repository/ApproveRepository.java
@@ -11,4 +11,6 @@ public interface ApproveRepository extends JpaRepository<Approve, Long> {
 
     Optional<Approve> getApproveByApproveId(Long approveId);
 
+    void deleteApproveByApproveId(Long approveId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/repository/FileRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/file/command/domain/repository/FileRepository.java
@@ -1,6 +1,8 @@
 package com.dao.momentum.file.command.domain.repository;
 
 import com.dao.momentum.file.command.domain.aggregate.File;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,8 @@ public interface FileRepository {
     List<File> findAllByAnnouncementId(Long announcementId);
 
     Optional<File> findByContractId(long contractId);
+
+    @Modifying
+    @Query("DELETE FROM File f WHERE f.approveId = :approveId")
+    void deleteByApprovalId(Long approveId);
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/BusinessTripRepository.java
@@ -3,6 +3,7 @@ package com.dao.momentum.work.command.domain.repository;
 import com.dao.momentum.work.command.domain.aggregate.BusinessTrip;
 import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +14,9 @@ public interface BusinessTripRepository extends JpaRepository<BusinessTrip, Long
 
     @Query(value = "SELECT * FROM business_trip WHERE approve_id = :approveId", nativeQuery = true)
     Optional<BusinessTrip> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM BusinessTrip b WHERE b.approveId = :approveId")
+    void deleteBusinessTripByApproveId(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/OvertimeRepository.java
@@ -2,9 +2,13 @@ package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.w3c.dom.stylesheets.LinkStyle;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,5 +16,15 @@ public interface OvertimeRepository extends JpaRepository<Overtime, Long> {
 
     @Query(value = "SELECT * FROM overtime WHERE approve_id = :approveId", nativeQuery = true)
     Optional<Overtime> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM Overtime o WHERE o.approveId = :approveId")
+    void deleteOvertimeByApproveId(Long approveId);
+
+    @Query(
+            value = "SELECT * FROM overtime WHERE start_at BETWEEN :startDate AND :endDate",
+            nativeQuery = true
+    )
+    List<Overtime> findOvertimesBetween(LocalDate startDate, LocalDate endDate);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/RemoteWorkRepository.java
@@ -1,17 +1,29 @@
 package com.dao.momentum.work.command.domain.repository;
 
-import com.dao.momentum.work.command.domain.aggregate.Overtime;
 import com.dao.momentum.work.command.domain.aggregate.RemoteWork;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface RemoteWorkRepository  extends JpaRepository<RemoteWork, Long> {
+public interface RemoteWorkRepository extends JpaRepository<RemoteWork, Long> {
 
     @Query(value = "SELECT * FROM remote_work WHERE approve_id = :approveId", nativeQuery = true)
     Optional<RemoteWork> findByApproveId(Long approveId);
+
+    @Query(
+            value = "SELECT * FROM remote_work WHERE start_at BETWEEN :startDate AND :endDate",
+            nativeQuery = true
+    )
+    List<RemoteWork> findRemoteWorksBetween(LocalDate startDate, LocalDate endDate);
+
+    @Modifying
+    @Query("DELETE FROM RemoteWork rw WHERE rw.approveId = :approveId")
+    void deleteRemoteWorkByApproveId(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/VacationRepository.java
@@ -2,15 +2,20 @@ package com.dao.momentum.work.command.domain.repository;
 
 import com.dao.momentum.work.command.domain.aggregate.Vacation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface VacationRepository  extends JpaRepository<Vacation, Long> {
+public interface VacationRepository extends JpaRepository<Vacation, Long> {
 
     @Query(value = "SELECT * FROM vacation WHERE approve_id = :approveId", nativeQuery = true)
     Optional<Vacation> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM Vacation v WHERE v.approveId = :approveId")
+    void deleteVacationByApproveId(Long approveId);
 
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/work/command/domain/repository/WorkCorrectionRepository.java
@@ -3,15 +3,20 @@ package com.dao.momentum.work.command.domain.repository;
 import com.dao.momentum.work.command.domain.aggregate.Vacation;
 import com.dao.momentum.work.command.domain.aggregate.WorkCorrection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface WorkCorrectionRepository  extends JpaRepository<WorkCorrection, Long> {
+public interface WorkCorrectionRepository extends JpaRepository<WorkCorrection, Long> {
 
     @Query(value = "SELECT * FROM work_correction WHERE approve_id = :approveId", nativeQuery = true)
     Optional<WorkCorrection> findByApproveId(Long approveId);
+
+    @Modifying
+    @Query("DELETE FROM WorkCorrection wc WHERE wc.approveId = :approveId")
+    void deleteWorkCorrectionByApproveId(Long approveId);
 
 }


### PR DESCRIPTION
closes #331
---

📌 개요
결재 문서 회수 기능 구현

🔨 주요 변경 사항
- `ApproveCommandController`에 `/documents/{documentId}`로 endpoint 작성
- 결재가 시작되지 않은 건에 한 해 결재 문서 회수 기능 구현
- 결재 문서 회수 시 결재 form, 결재선, 결재선 목록, 참조자, 결재 문서가 모두 삭제될 수 있게 설정
- 관련된 13개의 repository(결재 문서 8개 + 결재선 + 결재선 목록 + 참조자 + 파일 + 결재)에 delete 메소드 작성

✅ 리뷰 요청 사항

⭐ 관련 이슈
#331
