### PR TITLE
refactor : 결재 상세 조회 시 참조자의 empId도 조회할 수 있게 수정

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/query/dto/ApproveRefDTO.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 public class ApproveRefDTO {
 
+    private String empId;
     private String employeeDisplayName;
     private String departmentName;
     private String isConfirmed;

--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -100,6 +100,7 @@
     <!-- 결재 참조자 조회 -->
     <select id="getApproveRefs" resultType="com.dao.momentum.approve.query.dto.ApproveRefDTO">
         SELECT
+            ar.emp_id,
             CONCAT(e.name, ' ', p.name) AS employee_display_name,
             d.name AS department_name,
             ar.is_confirmed


### PR DESCRIPTION
closes #8 

---

📌 개요
결재 상세 조회 시 참조자의 empId도 조회할 수 있게 수정

🔨 주요 변경 사항
- `ApproveRefDTO`에서 empId가 같이 조회 되게 수정
- `ApproveDetailMapper`에서 emp_id 같이 조회 되게 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#8
