### PR TITLE
feat : 결재 문서 수정 기능

### DIFF
--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/controller/ApproveCommandController.java
@@ -91,4 +91,17 @@ public class ApproveCommandController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @PutMapping("/documents/{documentId}")
+    @Operation(summary = "결재 수정하기", description = "결재 내역을 수정 합니다.")
+    public ResponseEntity<ApiResponse<Void>> updateApproval(
+            @RequestBody @Valid ApproveRequest approveRequest,
+            @PathVariable Long documentId ,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long empId = Long.parseLong(userDetails.getUsername());
+
+        approveCommandService.updateApproval(approveRequest, documentId, empId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/application/service/ApproveCommandService.java
@@ -11,4 +11,7 @@ public interface ApproveCommandService {
     void viewAsReference(Long approveId, Long empId);
 
     void deleteApproval(Long approveId, Long empId);
+
+    void updateApproval(ApproveRequest approveRequest, Long approveId, Long empId);
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/approve/command/domain/aggregate/Approve.java
@@ -69,4 +69,8 @@ public class Approve {
         this.cancelAt = LocalDateTime.now();
     }
 
+    public void updateTitle(String approveTitle) {
+        this.approveTitle = approveTitle;
+    }
+
 }

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/exception/ErrorCode.java
@@ -96,8 +96,9 @@ public enum ErrorCode {
     INSUFFICIENT_DAY_OFF("30023", "남은 연차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_HALF_DAY_OFF("30024", "남은 반차 시간이 부족합니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_REFRESH("30025", "남은 리프레시 휴가 일수가 부족합니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_START_APPROVAL("30026", "결재가 시작되어 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_START_APPROVAL("30026", "결재가 시작되어 수정, 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NO_DELETE_PERMISSION("30027", "삭제할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
+    NO_UPDATE_PERMISSION("30028", "수정할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
 
     // 평가 오류 (40001 ~ 49999)
     // KPI 오류


### PR DESCRIPTION
closes #330

---

📌 개요
결재 문서 수정 기능 
(결재 문서 제목 외에는 삭제했다가 생성될 수 있게 설정함)

🔨 주요 변경 사항
- `ApproveCommandController` update관련 엔드 포인트 추가
- `ApproveCommandService`에 update 메소드 넣기
- `ApproveCommandServiceImpl`에서 실제 수정 메소드 수행 
  - 결재 문서 제목 수정 외에는 삭제 했다가 생성되게 수정 (현재 구조가 너무 복잡해서 만들어져 있는 것을 최대한 활용하게 하기 위함)
- `Approve`에 update 메소드 추가
- `ErrorCode`에 update시 이미 결재선이 시작됐거나 권한이 없는 경우 접근하지 못하게 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#330
