### PR TITLE
fix : 문서 상세 조회 시 결재 타입에 여러 타입이 들어올 수 있게 수정

### DIFF
--- a/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
+++ b/momentum-dao-be/src/main/resources/mappers/approve/ApproveDetailMapper.xml
@@ -18,22 +18,22 @@
             e.name AS employee_name,
             d.name AS department_name,
 
-            CASE
-                WHEN a.emp_id = #{empId} THEN 'WRITER'
-                WHEN EXISTS (
-                    SELECT 1
-                    FROM approve_line al2
-                    JOIN approve_line_list ali2 ON al2.approve_line_id = ali2.approve_line_id
-                    WHERE al2.approve_id = a.approve_id AND ali2.emp_id = #{empId}
-                    ) THEN 'APPROVAL'
-                WHEN EXISTS (
-                    SELECT 1
-                    FROM approve_ref ar2
-                    WHERE ar2.approve_id = a.approve_id AND ar2.emp_id = #{empId}
-                    ) THEN 'REFERENCE'
-                WHEN #{isAdmin} = TRUE THEN 'MASTER'
-                ELSE NULL
-            END AS received_type
+            TRIM(TRAILING ',' FROM CONCAT(
+            CASE WHEN a.emp_id = #{empId} THEN 'WRITER,' ELSE '' END,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM approve_line al2
+                JOIN approve_line_list ali2 ON al2.approve_line_id = ali2.approve_line_id
+                WHERE al2.approve_id = a.approve_id AND ali2.emp_id = #{empId}
+            ) THEN 'APPROVAL,' ELSE '' END,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM approve_ref ar2
+                WHERE ar2.approve_id = a.approve_id AND ar2.emp_id = #{empId}
+            ) THEN 'REFERENCE,' ELSE '' END,
+                CASE WHEN #{isAdmin} = TRUE THEN 'MASTER,' ELSE '' END
+            )) AS received_type
+
 
         FROM approve a
         JOIN employee e ON a.emp_id = e.emp_id


### PR DESCRIPTION
closes #8 

---

📌 개요
문서 상세 조회 시 결재 타입에 여러 타입이 들어올 수 있게 수정

🔨 주요 변경 사항
- 문서 상세 조회 시 해당 사원이 어떤 역할인지 설정 (보낸 사람, 결재자, 참조자, 마스터 관리자)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#8
