### PR TITLE
refactor: 백엔드 서버 WARN 로그 해결

### DIFF
--- a/momentum-dao-be/src/main/resources/application.yml
+++ b/momentum-dao-be/src/main/resources/application.yml
@@ -12,7 +12,6 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
-        dialect: org.hibernate.dialect.MariaDBDialect
   servlet:
     multipart:
       max-file-size: 5MB


### PR DESCRIPTION
closes #000

---

📌 개요
- `application.yml` 설정 수정

🔨 주요 변경 사항
- 아래의 WARN 로그 뜨지 않도록 조치
  - `2025-07-17T11:14:56.941+09:00  WARN 36028 --- [  restartedMain] org.hibernate.orm.deprecation            : HHH90000025: MariaDBDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)`
  - `deprecation`에 대한 경고로 판단되어 수정함

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
