### PR TITLE
chore: k8s ingress 분기용 context-path 설정, spring actuator health endpoint 활성화, redis ssl 연결 설정

### DIFF
--- a/momentum-dao-be/build.gradle
+++ b/momentum-dao-be/build.gradle
@@ -83,6 +83,9 @@ dependencies {
 
     // 엑셀 다운로드
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
+
+    // spring actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 dependencyManagement {

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/RedisConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -33,10 +34,11 @@ public class RedisConfig {
         redisStandaloneConfiguration.setPort(Integer.parseInt(redisPort));
         redisStandaloneConfiguration.setPassword(redisPassword);
 
-        LettuceConnectionFactory lettuceConnectionFactory =
-                new LettuceConnectionFactory(redisStandaloneConfiguration);
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()  // TLS 활성화
+                .build();
 
-        return lettuceConnectionFactory;
+        return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
     }
 
     @Bean

--- a/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
+++ b/momentum-dao-be/src/main/java/com/dao/momentum/common/config/SecurityConfig.java
@@ -101,7 +101,8 @@ public class SecurityConfig {
                 "/employees/reset-password",
                 "/employees/reset-password/request",
                 "/swagger-ui/**",
-                "/v3/api-docs/**"
+                "/v3/api-docs/**",
+                "/actuator/health"
         ).permitAll();
     }
 

--- a/momentum-dao-be/src/main/resources/application.yml
+++ b/momentum-dao-be/src/main/resources/application.yml
@@ -41,6 +41,8 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
       timeout: 6000ms  # ?? ????
+      ssl:
+        enabled: true
       lettuce:
         pool:
           max-active: 10  # ?? ?? ?? ?
@@ -86,3 +88,16 @@ naver:
 batch:
   server:
     url: ${BATCH_SERVER_URL} # 알림 배치 서버
+
+server:
+  servlet:
+    context-path: /api/backend/v1
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
k8s ingress 분기용 context-path 설정, spring actuator health endpoint 활성화, redis ssl 연결 설정

closes #000

---

📌 개요
- k8s ingress 분기용 context-path 설정(/api/backend-batch/v1)
- spring actuator health endpoint 활성화(+security filter permit all)
- redis ssl 연결 설정(elasticache)